### PR TITLE
Accept a Float for rotate_rates to set all screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A default `config.json.example` file is included for reference. Copy this file t
 "display_standings"       Bool    Display standings for the provided preferred_division.
 "rotate_games"            Bool    Rotate through each game of the day every 15 seconds.
 "rotate_rates"            Dict    Dictionary of Floats. Each type of screen can use a different rotation rate. Valid types: "live", "pregame", "final".
+                          Float   A Float can be used to set all screen types to the same rotate rate.
 "scroll_until_finished"   Bool    If scrolling text takes longer than the rotation rate, wait to rotate until scrolling is done.
 "slowdown_scrolling"      Bool    If your Pi is unable to handle the normal refresh rate while scrolling, this will slow it down.
 "debug_enabled"           Bool    Game and other debug data is written to your console.

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -23,8 +23,12 @@ class ScoreboardConfig:
 
   def check_rotate_rates(self):
     if isinstance(self.rotate_rates, dict) == False:
-      print "Warning: rotate_rates should be a dictionary. Using default value. {}".format(DEFAULT_ROTATE_RATES)
-      self.rotate_rates = DEFAULT_ROTATE_RATES
+      try:
+        rate = float(self.rotate_rates)
+        self.rotate_rates = {"live": rate, "final": rate, "pregame": rate}
+      except:
+        print "Warning: rotate_rates should be a Dict or Float. Using default value. {}".format(DEFAULT_ROTATE_RATES)
+        self.rotate_rates = DEFAULT_ROTATE_RATES
 
     for key, value in list(self.rotate_rates.items()):
       try:


### PR DESCRIPTION
A simple change that allows for a user to specify a single Float for rotate_rates instead of a Dict. This will set all screens to that value.