### PR TITLE
Keep scoreboard locked on the preferred team when that game is live

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,16 @@ Make sure your Raspberry Pi's timezone is configured to your local time zone. Th
 A default `config.json.example` file is included for reference. Copy this file to `config.json` and modify the values as needed.
 
 ```
-"preferred_team"          String  Pick a team to display a game for. Example: "Cubs"
-"preferred_division"      String  Pick a division to display standings for when display_standings is true. Example: "NL Central"
-"display_standings"       Bool    Display standings for the provided preferred_division.
-"rotate_games"            Bool    Rotate through each game of the day every 15 seconds.
-"rotate_rates"            Dict    Dictionary of Floats. Each type of screen can use a different rotation rate. Valid types: "live", "pregame", "final".
-                          Float   A Float can be used to set all screen types to the same rotate rate.
-"scroll_until_finished"   Bool    If scrolling text takes longer than the rotation rate, wait to rotate until scrolling is done.
-"slowdown_scrolling"      Bool    If your Pi is unable to handle the normal refresh rate while scrolling, this will slow it down.
-"debug_enabled"           Bool    Game and other debug data is written to your console.
+"preferred_team"              String  Pick a team to display a game for. Example: "Cubs"
+"preferred_division"          String  Pick a division to display standings for when display_standings is true. Example: "NL Central"
+"display_standings"           Bool    Display standings for the provided preferred_division.
+"rotate_games"                Bool    Rotate through each game of the day every 15 seconds.
+"rotate_rates"                Dict    Dictionary of Floats. Each type of screen can use a different rotation rate. Valid types: "live", "pregame", "final".
+                              Float   A Float can be used to set all screen types to the same rotate rate.
+"stay_on_live_preferred_team" Bool    Stop rotating through games when your preferred team is currently live.
+"scroll_until_finished"       Bool    If scrolling text takes longer than the rotation rate, wait to rotate until scrolling is done.
+"slowdown_scrolling"          Bool    If your Pi is unable to handle the normal refresh rate while scrolling, this will slow it down.
+"debug_enabled"               Bool    Game and other debug data is written to your console.
 ```
 
 ### Flags

--- a/config.json.example
+++ b/config.json.example
@@ -4,6 +4,7 @@
 	"display_standings": false,
 	"rotate_games": false,
 	"rotate_rates": { "live": 15.0, "final": 15.0, "pregame": 15.0 },
+	"stay_on_live_preferred_team": true,
 	"scroll_until_finished": true,
 	"slower_scrolling": false,
 	"debug_enabled": false

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -13,6 +13,7 @@ class ScoreboardConfig:
     self.preferred_division = json.get("preferred_division", "NL Central")
     self.rotate_games = json.get("rotate_games", False)
     self.rotate_rates = json.get("rotate_rates", DEFAULT_ROTATE_RATES)
+    self.stay_on_live_preferred_team = json.get("stay_on_live_preferred_team", True)
     self.display_standings = json.get("display_standings", False)
     self.scroll_until_finished = json.get("scroll_until_finished", True)
     self.slowdown_scrolling = json.get("slowdown_scrolling", False)

--- a/renderers/games.py
+++ b/renderers/games.py
@@ -134,9 +134,24 @@ class GameRenderer:
         self.data_needs_refresh = True
         self.scroll_finished = False
         self.current_scrolling_text_pos = self.canvas.width
-        if self.config.rotate_games:
+        if self.__should_rotate_to_next_game(overview):
           current_game_index = bump_counter(current_game_index, self.games)
           game = self.games[current_game_index]
+
+  def __should_rotate_to_next_game(self, overview):
+    if self.config.rotate_games == False:
+      return False
+
+    stay_on_preferred_team = self.config.preferred_team and self.config.stay_on_live_preferred_team
+    if stay_on_preferred_team == False:
+      return True
+
+    showing_preferred_team = self.config.preferred_team in [overview.away_team_name, overview.home_team_name]
+    current_game_is_live = (overview.status == IN_PROGRESS or overview.status == WARMUP or overview.status == GAME_OVER)
+    if showing_preferred_team and current_game_is_live:
+      return False
+
+    return True
 
   def __get_game_from_args(self):
     """Returns the index of the game to render.


### PR DESCRIPTION
Add a config option (default is true) to keep the scoreboard pinned to your preferred team while that team is currently in warmup, live or in "game over" status (which seems to last for about 5 minutes after the game ends).

Closes #21 (We can create a new issue to allow us to stay on the final scoreboard for a set amount of time)