### PR TITLE
Add option to display standings on an offday.

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -2,6 +2,7 @@
 	"preferred_team": "Cubs",
 	"preferred_division": "NL Central",
 	"display_standings": false,
+	"display_standings_on_offday": true,
 	"rotate_games": false,
 	"rotate_rates": { "live": 15.0, "final": 15.0, "pregame": 15.0 },
 	"scroll_until_finished": true,

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -14,6 +14,7 @@ class ScoreboardConfig:
     self.rotate_games = json.get("rotate_games", False)
     self.rotate_rates = json.get("rotate_rates", DEFAULT_ROTATE_RATES)
     self.display_standings = json.get("display_standings", False)
+    self.display_standings_on_offday = json.get("display_standings_on_offday", True)
     self.scroll_until_finished = json.get("scroll_until_finished", True)
     self.slowdown_scrolling = json.get("slowdown_scrolling", False)
     self.debug_enabled = json.get("debug_enabled", False)

--- a/main.py
+++ b/main.py
@@ -29,14 +29,24 @@ year = now.year
 month = now.month
 day = now.day
 
-if config.display_standings:
-  standings = mlbgame.standings(datetime.datetime(year, month, day))
+def display_standings(matrix, config, date):
+  standings = mlbgame.standings(date)
   division = next(division for division in standings.divisions if division.name == config.preferred_division)
   renderers.standings.render(matrix, matrix.CreateFrameCanvas(), division)
+
+if config.display_standings:
+	display_standings(matrix, config, datetime.datetime(year, month, day))
 else:
   while True:
     games = mlbgame.day(year, month, day)
     if not len(games):
-      renderers.offday.render(matrix, matrix.CreateFrameCanvas())
+      if config.display_standings_on_offday:
+        try:
+          display_standings(matrix, config, datetime.datetime(year, month, day))
+        except:
+          # Out of season off days don't always return standings so fall back on the offday renderer
+          renderers.offday.render(matrix, matrix.CreateFrameCanvas())
+      else:
+        renderers.offday.render(matrix, matrix.CreateFrameCanvas())
     else:
       GameRenderer(matrix, matrix.CreateFrameCanvas(), games, config).render()


### PR DESCRIPTION
If there are no games for the day, display the current standings instead. Turn this off with the "display_standings_on_offday" config option.

Closes #73