### PR TITLE
Add config option to change the end of day time

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A default `config.json.example` file is included for reference. Copy this file t
                               Float   A Float can be used to set all screen types to the same rotate rate.
 "stay_on_live_preferred_team" Bool    Stop rotating through games when your preferred team is currently live.
 "scroll_until_finished"       Bool    If scrolling text takes longer than the rotation rate, wait to rotate until scrolling is done.
+"end_of_day"                  String  A 24-hour time you wish to consider the end of the previous day before starting to display the current day's games. Uses local time from your pi.
 "slowdown_scrolling"          Bool    If your Pi is unable to handle the normal refresh rate while scrolling, this will slow it down.
 "debug_enabled"               Bool    Game and other debug data is written to your console.
 ```

--- a/config.json.example
+++ b/config.json.example
@@ -7,6 +7,7 @@
 	"rotate_rates": { "live": 15.0, "final": 15.0, "pregame": 15.0 },
 	"stay_on_live_preferred_team": true,
 	"scroll_until_finished": true,
+	"end_of_day": "00:00",
 	"slower_scrolling": false,
 	"debug_enabled": false
 }

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -18,6 +18,7 @@ class ScoreboardConfig:
     self.display_standings = json.get("display_standings", False)
     self.display_standings_on_offday = json.get("display_standings_on_offday", True)
     self.scroll_until_finished = json.get("scroll_until_finished", True)
+    self.end_of_day = json.get("end_of_day", "00:00")
     self.slowdown_scrolling = json.get("slowdown_scrolling", False)
     self.debug_enabled = json.get("debug_enabled", False)
     self.coords = self.get_coords(width, height)

--- a/main.py
+++ b/main.py
@@ -25,9 +25,11 @@ debug.set_debug_status(config)
 # Render the current standings or today's games depending on
 # the provided arguments
 now = datetime.datetime.now()
+end_of_day = datetime.datetime.strptime(config.end_of_day, "%H:%M").replace(year=now.year, month=now.month, day=now.day)
+date_offset = -1 if end_of_day > now else 0
 year = now.year
 month = now.month
-day = now.day
+day = now.day + date_offset
 
 def display_standings(matrix, config, date):
   standings = mlbgame.standings(date)


### PR DESCRIPTION
Closes #52 

I chose midnight as the default because that is how the scoreboard operates currently.