### PR TITLE
Prevent crash when game's time is unavailable

### DIFF
--- a/data/pregame.py
+++ b/data/pregame.py
@@ -8,7 +8,12 @@ class Pregame:
   def __init__(self, overview):
     self.home_team = overview.home_name_abbrev
     self.away_team = overview.away_name_abbrev
-    self.start_time = self.__convert_time(overview.time + overview.ampm)
+
+    try:
+      self.start_time = self.__convert_time(overview.time + overview.ampm)
+    except:
+      self.start_time = "TBD"
+
     self.status = overview.status
 
     try:


### PR DESCRIPTION
If a double header doesn't have an exact start time, the time property returns "Gm 2" or something similar. Obviously this can't be parsed when converting the time zone. If it fails to convert, just use a TBD for now.