### PR TITLE
Error handling fixes

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -91,6 +91,9 @@ class Data:
         attempts_remaining -= 1
         time.sleep(NETWORK_RETRY_SLEEP_TIME)
 
+    # If we run out of retries, just move on to the next game
+    if attempts_remaining <= 0 and self.config.rotate_games:
+      self.advance_to_next_game()
 
   #
   # Standings


### PR DESCRIPTION
Currenly after 5 retries, the 5 retries just start over again on the same game. If we have rotate on, we should check the next game to see if we have issues downloading that one too.