### PR TITLE
Refactor string formatters

### DIFF
--- a/data/pregame.py
+++ b/data/pregame.py
@@ -48,8 +48,8 @@ class Pregame:
     return game_time_eastern.astimezone(tzlocal.get_localzone()).strftime('%I:%M%p').lstrip('0')
 
   def __str__(self):
-    s =  "<%s %s> " % (self.__class__.__name__, hex(id(self)))
-    s += "%s @ %s, (%s), %s vs %s" % (
+    s = "<{} {}> {} @ {}; {}; {} vs {}".format(
+      self.__class__.__name__, hex(id(self)),
       self.away_team, self.home_team, self.start_time,
       self.away_starter, self.home_starter)
     return s

--- a/data/scoreboard.py
+++ b/data/scoreboard.py
@@ -22,8 +22,8 @@ class Scoreboard:
     self.game_status = overview.status
 
   def __str__(self):
-    s = "<%s %s> " % (self.__class__.__name__, hex(id(self)))
-    s += "%s (%s) @ %s (%s), Status: %s, Inning: (Number, %s, State: %s), B:%s S:%s O:%s, Bases: %s" % (
+    s = "<{} {}> {} ({}) @ {} ({}); Status: {}; Inning: (Number: {}; State: {}); B:{} S:{} O:{}; Bases: {}".format(
+      self.__class__.__name__, hex(id(self)),
       self.away_team.abbrev, str(self.away_team.runs),
       self.home_team.abbrev, str(self.home_team.runs),
       self.game_status,

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -73,11 +73,11 @@ class ScoreboardConfig:
     return j
 
   def get_coords(self, width, height):
-    filename = "ledcoords/w%sh%s.json" % (width, height)
+    filename = "ledcoords/w{}h{}.json".format(width, height)
     coords = self.read_json(filename)
     if not coords:
       # Fall back to default example file
-      filename = "%s.example" % (filename)
+      filename = "{}.example".format(filename)
       coords = self.read_json(filename)
       if not coords:
         # Unsupported coordinates

--- a/renderers/final.py
+++ b/renderers/final.py
@@ -21,7 +21,7 @@ class Final:
     return self.__render_scroll_text()
 
   def __render_scroll_text(self):
-    scroll_text = "W: %s %s-%s L: %s %s-%s" % (
+    scroll_text = "W: {} {}-{} L: {} {}-{}".format(
       self.game.winning_pitcher, self.game.winning_pitcher_wins, self.game.winning_pitcher_losses,
       self.game.losing_pitcher, self.game.losing_pitcher_wins, self.game.losing_pitcher_losses)
     if self.game.save_pitcher:

--- a/renderers/offday.py
+++ b/renderers/offday.py
@@ -38,6 +38,5 @@ class OffdayRenderer:
       pass # I hate the offseason and off days.
 
   def __str_(self):
-    s = "<%s %s> " % (self.__class__.__name__, hex(id(self)))
-    s += "Date: %s" % (self.data.date())
+    s = "<{} {}> Date: {}".format(self.__class__.__name__, hex(id(self)), self.data.date())
     return s

--- a/renderers/pregame.py
+++ b/renderers/pregame.py
@@ -23,7 +23,7 @@ class Pregame:
   def __render_matchup(self):
     away_text = '{:>3s}'.format(self.game.away_team)
     home_text = '{:3s}'.format(self.game.home_team)
-    teams_text = "%s  %s" % (away_text, home_text)
+    teams_text = "{}  {}".format(away_text, home_text)
     teams_text_x = center_text_position(teams_text, self.canvas.width)
     at_x = center_text_position("@", self.canvas.width)
     graphics.DrawText(self.canvas, self.font, teams_text_x, self.coords["matchup"]["y"], self.text_color, teams_text)


### PR DESCRIPTION
Python recommends using the .format() method and we had a combination of both in various spots of our code. Conform them all to the recommended method.