### PR TITLE
Update games on final

### DIFF
--- a/renderers/main.py
+++ b/renderers/main.py
@@ -69,6 +69,11 @@ class MainRenderer:
           game = self.data.advance_to_next_game()
 
         self.data.refresh_overview()
+
+        if Status.is_complete(self.data.overview.status):
+          if Final(self.data.current_game()).winning_team == 'Unknown':
+            self.data.refresh_games()
+
         if endtime - self.data.games_refresh_time >= GAMES_REFRESH_RATE:
           self.data.refresh_games()
 

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -71,7 +71,7 @@ class MainRenderer:
         self.data.refresh_overview()
 
         if Status.is_complete(self.data.overview.status):
-          if Final(self.data.current_game()).winning_team == 'Unknown':
+          if Final(self.data.current_game()).winning_pitcher == 'Unknown':
             self.data.refresh_games()
 
         if endtime - self.data.games_refresh_time >= GAMES_REFRESH_RATE:


### PR DESCRIPTION
This fixes an issue where the winning and losing pitchers right after a game ends show up as `Unknown`. This will check if the game is over and the winning pitcher is `Unknown` and then update the main `games` object so we get updated winning/losing pitcher status right away.