### PR TITLE
Update the date after 'end_of_day' has expired

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -21,7 +21,7 @@ class Data:
     self.config = config
 
     # Parse today's date and see if we should use today or yesterday
-    self.year, self.month, self.day = self.__parse_today()
+    self.set_current_date()
 
     # Flag to determine when to refresh data
     self.needs_refresh = True
@@ -50,6 +50,9 @@ class Data:
   def date(self):
     return datetime(self.year, self.month, self.day)
 
+  def set_current_date(self):
+    self.year, self.month, self.day = self.__parse_today()
+
 
   #
   # mlbgame refresh
@@ -61,10 +64,16 @@ class Data:
       debug.error("Failed to refresh standings.")
 
   def refresh_games(self):
+
+    debug.log("Updating games for {}/{}/{}".format(self.month, self.day, self.year))
     attempts_remaining = 5
     while attempts_remaining > 0:
       try:
+        current_day = self.day
+        self.set_current_date()
         self.games = mlbgame.day(self.year, self.month, self.day)
+        if current_day != self.day:
+          self.current_game_index = self.game_index_for_preferred_team()
         self.games_refresh_time = time.time()
         break
       except URLError, e:

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -69,14 +69,14 @@ class MainRenderer:
           self.scrolling_text_pos = self.canvas.width
           game = self.data.advance_to_next_game()
 
+        if endtime - self.data.games_refresh_time >= GAMES_REFRESH_RATE:
+          self.data.refresh_games()
+
         self.data.refresh_overview()
 
         if Status.is_complete(self.data.overview.status):
           if Final(self.data.current_game()).winning_pitcher == 'Unknown':
             self.data.refresh_games()
-
-        if endtime - self.data.games_refresh_time >= GAMES_REFRESH_RATE:
-          self.data.refresh_games()
 
   def __rotate_rate_for_status(self, status):
     rotate_rate = self.data.config.live_rotate_rate


### PR DESCRIPTION
When we update the master games list, we'll also try and update the date for the day. If the `end_of_day` has passed, we can move on to the next day. This alleviates the need to reboot the scoreboard in order to get the current date to start showing.

Closes #115 