### PR TITLE
Add --led-pixel-mapper to support rotation and U-mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ You can configure your LED matrix with the same flags used in the [rpi-rgb-led-m
 --led-slowdown-gpio       Slow down writing to GPIO. Range: 0..4. (Default: 1)
 --led-no-hardware-pulse   Don't use hardware pin-pulse generation.
 --led-rgb-sequence        Switch if your matrix has led colors swapped. (Default: RGB)
+--led-pixel-mapper        Apply pixel mappers. e.g Rotate:90, U-mapper
 --led-row-addr-type       0 = default; 1 = AB-addressed panels. (Default: 0)
 --led-multiplexing        Multiplexing type: 0 = direct; 1 = strip; 2 = checker; 3 = spiral; 4 = Z-strip; 5 = ZnMirrorZStripe; 6 = coreman; 7 = Kaler2Scan; 8 = ZStripeUneven. (Default: 0)
 ```

--- a/utils.py
+++ b/utils.py
@@ -35,6 +35,7 @@ def args():
   parser.add_argument("--led-slowdown-gpio", action="store", help="Slow down writing to GPIO. Range: 0..4. (Default: 1)", choices=range(5), type=int)
   parser.add_argument("--led-no-hardware-pulse", action="store", help="Don't use hardware pin-pulse generation.")
   parser.add_argument("--led-rgb-sequence", action="store", help="Switch if your matrix has led colors swapped. (Default: RGB)", default="RGB", type=str)
+  parser.add_argument("--led-pixel-mapper", action="store", help="Apply pixel mappers. e.g \"Rotate:90\"", default="", type=str)
   parser.add_argument("--led-row-addr-type", action="store", help="0 = default; 1 = AB-addressed panels. (Default: 0)", default=0, type=int, choices=[0,1])
   parser.add_argument("--led-multiplexing", action="store",
                       help="Multiplexing type: 0 = direct; 1 = strip; 2 = checker; 3 = spiral; 4 = Z-strip; 5 = ZnMirrorZStripe; 6 = coreman; 7 = Kaler2Scan; 8 = ZStripeUneven. (Default: 0)", default=0, type=int)
@@ -57,6 +58,7 @@ def led_matrix_options(args):
   options.brightness = args.led_brightness
   options.pwm_lsb_nanoseconds = args.led_pwm_lsb_nanoseconds
   options.led_rgb_sequence = args.led_rgb_sequence
+  options.pixel_mapper_config = args.led_pixel_mapper
 
   if args.led_show_refresh:
     options.show_refresh_rate = 1


### PR DESCRIPTION
This is necessary to support the U-mapper and rotation functions from the rpi-rgb-led-matrix library. I based it on the samplebase.py from the library. This allows users to rotate and flip portions of their panel, in my case, it allows me to support a 64x64 matrix from two chained 32x64 matrices.