### PR TITLE
Fix duplicate stat keys

### DIFF
--- a/ledcoords/w128h32.json.example
+++ b/ledcoords/w128h32.json.example
@@ -156,7 +156,7 @@
     "divider": {
       "x": 13
     },
-    "stat": {
+    "stat_title": {
       "x": 28
     },
     "team": {

--- a/ledcoords/w32h32.json.example
+++ b/ledcoords/w32h32.json.example
@@ -153,7 +153,7 @@
     "divider": {
       "x": 13
     },
-    "stat": {
+    "stat_title": {
       "x": 28
     },
     "team": {

--- a/ledcoords/w64h32.json.example
+++ b/ledcoords/w64h32.json.example
@@ -153,7 +153,7 @@
     "divider": {
       "x": 13
     },
-    "stat": {
+    "stat_title": {
       "x": 28
     },
     "team": {

--- a/renderers/standings.py
+++ b/renderers/standings.py
@@ -29,7 +29,7 @@ class StandingsRenderer:
     starttime = time.time()
     while True:
       offset = coords["offset"]
-      graphics.DrawText(self.canvas, font["font"], coords["stat"]["x"], offset, self.stat_color, stat.upper())
+      graphics.DrawText(self.canvas, font["font"], coords["stat_title"]["x"], offset, self.stat_color, stat.upper())
       for team in self.data.standings_for_preferred_division().teams:
         abbrev = '{:3s}'.format(team.team_abbrev)
         team_text = '%s' % abbrev


### PR DESCRIPTION
Using the same name for both the stat title and the actual stat was a little confusing. Changed the stat title to actually be `stat_title` instead.