### PR TITLE
Added some error checking in case the matrix library wasn't recompiled

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import mlbgame
 import debug
 
 SCRIPT_NAME = "MLB LED Scoreboard"
-SCRIPT_VERSION = "1.5.0"
+SCRIPT_VERSION = "1.5.1"
 
 # Get supplied command line arguments
 args = args()

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ from rgbmatrix import RGBMatrixOptions, graphics
 import collections
 import argparse
 import os
+import debug
 
 def get_file(path):
   dir = os.path.dirname(__file__)
@@ -58,7 +59,11 @@ def led_matrix_options(args):
   options.brightness = args.led_brightness
   options.pwm_lsb_nanoseconds = args.led_pwm_lsb_nanoseconds
   options.led_rgb_sequence = args.led_rgb_sequence
-  options.pixel_mapper_config = args.led_pixel_mapper
+  try:
+    options.pixel_mapper_config = args.led_pixel_mapper
+  except AttributeError:
+    debug.warning("Your compiled RGB Matrix Library is out of date.")
+    debug.warning("The --led-pixel-mapper argument will not work until it is updated.")
 
   if args.led_show_refresh:
     options.show_refresh_rate = 1


### PR DESCRIPTION
When we updated the matrix library we didn't take into account that it would need to be recompiled during update. This should check if the library isn't up to date and give a subtle warning instead of a hard crash if it has not. Most people won't need to update the library anyways.