### PR TITLE
Add notes or reason to the status screens

### DIFF
--- a/data/scoreboard.py
+++ b/data/scoreboard.py
@@ -41,7 +41,7 @@ class Scoreboard:
     return None
 
   def __str__(self):
-    s = "<{} {}> {} ({}) @ {} ({}); Status: {}; Inning: (Number: {}; State: {}); B:{} S:{} O:{}; Bases: {}".format(
+    s = "<{} {}> {} ({}) @ {} ({}); Status: {}; Inning: (Number: {}; State: {}); B:{} S:{} O:{}; Bases: {};".format(
       self.__class__.__name__, hex(id(self)),
       self.away_team.abbrev, str(self.away_team.runs),
       self.home_team.abbrev, str(self.home_team.runs),
@@ -52,4 +52,8 @@ class Scoreboard:
       str(self.pitches.strikes),
       str(self.outs.number),
       str(self.bases))
+    if self.reason:
+      s += " Reason: '{}';".format(self.reason)
+    if self.note:
+      s += " Notes: '{}';".format(self.note)
     return s

--- a/data/scoreboard.py
+++ b/data/scoreboard.py
@@ -21,6 +21,25 @@ class Scoreboard:
     self.outs = Outs(overview)
     self.game_status = overview.status
 
+    try:
+      self.note = overview.note
+    except:
+      self.note = None
+
+    try:
+      self.reason = overview.reason
+    except:
+      self.reason = None
+
+  def get_text_for_reason(self):
+    if self.note:
+      return self.note
+
+    if self.reason:
+      return self.reason
+
+    return None
+
   def __str__(self):
     s = "<{} {}> {} ({}) @ {} ({}); Status: {}; Inning: (Number: {}; State: {}); B:{} S:{} O:{}; Bases: {}".format(
       self.__class__.__name__, hex(id(self)),

--- a/data/status.py
+++ b/data/status.py
@@ -6,17 +6,18 @@ class Status:
   FINAL = 'Final'
   GAME_OVER = 'Game Over'
   IN_PROGRESS = 'In Progress'
-  MANAGER_CHALLENGE = "Manager Challenge"
+  MANAGER_CHALLENGE = 'Manager Challenge'
   REVIEW = 'Review'
   PRE_GAME = 'Pre-Game'
   POSTPONED = 'Postponed'
   SCHEDULED = 'Scheduled'
+  SUSPENDED = 'Suspended'
   WARMUP = 'Warmup'
 
   @staticmethod
   def is_static(status):
     """Returns whether the game being currently displayed has no text to scroll"""
-    return status in [Status.IN_PROGRESS, Status.CANCELLED, Status.DELAYED, Status.DELAYED_START, Status.POSTPONED, Status.MANAGER_CHALLENGE, Status.REVIEW]
+    return status in [Status.IN_PROGRESS, Status.CANCELLED, Status.DELAYED, Status.DELAYED_START, Status.POSTPONED, Status.SUSPENDED, Status.MANAGER_CHALLENGE, Status.REVIEW]
 
   @staticmethod
   def is_pregame(status):
@@ -37,7 +38,7 @@ class Status:
   def is_irregular(status):
     """Returns whether game is in an irregular state, such as delayed, postponed, cancelled,
     or in a challenge."""
-    return status in [Status.POSTPONED, Status.DELAYED, Status.DELAYED_START, Status.CANCELLED, Status.MANAGER_CHALLENGE]
+    return status in [Status.POSTPONED, Status.SUSPENDED, Status.DELAYED, Status.DELAYED_START, Status.CANCELLED, Status.MANAGER_CHALLENGE]
 
   @staticmethod
   def is_fresh(status):

--- a/ledcolors/scoreboard.json.example
+++ b/ledcolors/scoreboard.json.example
@@ -118,10 +118,17 @@
       "b": 59
     }
   },
-  "status_text": {
-    "r": 255,
-    "g": 235,
-    "b": 59
+  "status": {
+    "text": {
+      "r": 255,
+      "g": 235,
+      "b": 59
+    },
+    "scrolling_text": {
+      "r": 255,
+      "g": 235,
+      "b": 59
+    }
   },
   "standings": {
     "background": {

--- a/ledcoords/w128h32.json.example
+++ b/ledcoords/w128h32.json.example
@@ -170,8 +170,8 @@
   },
   "status": {
     "text": {
-      "x": 32,
-      "y": 20,
+      "x": 96,
+      "y": 14,
       "short_text": false
     },
     "scrolling_text": {

--- a/ledcoords/w128h32.json.example
+++ b/ledcoords/w128h32.json.example
@@ -168,10 +168,17 @@
       }
     }
   },
-  "status_text": {
-    "x": 32,
-    "y": 20,
-    "short_text": false
+  "status": {
+    "text": {
+      "x": 32,
+      "y": 20,
+      "short_text": false
+    },
+    "scrolling_text": {
+      "x": 0,
+      "y": 30,
+      "width": 128
+    }
   },
   "teams": {
     "background": {

--- a/ledcoords/w32h32.json.example
+++ b/ledcoords/w32h32.json.example
@@ -168,10 +168,17 @@
       }
     }
   },
-  "status_text": {
-    "x": 16,
-    "y": 20,
-    "short_text": true
+  "status": {
+    "text": {
+      "x": 16,
+      "y": 20,
+      "short_text": true
+    },
+    "scrolling_text": {
+      "x": 0,
+      "y": 31,
+      "width": 32
+    }
   },
   "teams": {
     "background": {

--- a/ledcoords/w64h32.json.example
+++ b/ledcoords/w64h32.json.example
@@ -168,10 +168,17 @@
       }
     }
   },
-  "status_text": {
-    "x": 32,
-    "y": 20,
-    "short_text": false
+  "status": {
+    "text": {
+      "x": 32,
+      "y": 20,
+      "short_text": false
+    },
+    "scrolling_text": {
+      "x": 0,
+      "y": 31,
+      "width": 64
+    }
   },
   "teams": {
     "background": {

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -47,7 +47,7 @@ class MainRenderer:
         refresh_rate = SCROLL_TEXT_SLOW_RATE
 
       # If we're not scrolling anything, scroll is always finished.
-      if Status.is_static(self.data.overview.status):
+      if Status.is_static(self.data.overview.status) and not Scoreboard(self.data.overview).get_text_for_reason():
         self.scrolling_finished = True
 
       time.sleep(refresh_rate)
@@ -122,7 +122,12 @@ class MainRenderer:
     # Draw the scoreboar renderer
     elif Status.is_irregular(overview.status):
       scoreboard = Scoreboard(overview)
-      StatusRenderer(self.canvas, scoreboard, self.data).render()
+      if scoreboard.get_text_for_reason():
+        scroll_max_x = self.__max_scroll_x(self.data.config.layout.coords("status.scrolling_text"))
+        renderer = StatusRenderer(self.canvas, scoreboard, self.data, self.scrolling_text_pos)
+        self.__update_scrolling_text_pos(renderer.render())
+      else:
+        StatusRenderer(self.canvas, scoreboard, self.data).render()
     else:
       scoreboard = Scoreboard(overview)
       ScoreboardRenderer(self.canvas, scoreboard, self.data).render()

--- a/renderers/scrollingtext.py
+++ b/renderers/scrollingtext.py
@@ -24,7 +24,6 @@ class ScrollingText:
 			return pos
 
 		else:
-			print "Centering Scrolling Text because it's too short"
 			graphics.DrawText(self.canvas, self.font["font"], self.__center_position(), self.y, self.text_color, self.text)
 			return 0
 

--- a/renderers/scrollingtext.py
+++ b/renderers/scrollingtext.py
@@ -1,4 +1,5 @@
 from rgbmatrix import graphics
+from utils import center_text_position
 
 class ScrollingText:
 	def __init__(self, canvas, x, y, width, font, text_color, background_color, text):
@@ -12,11 +13,24 @@ class ScrollingText:
 		self.width = width
 
 	def render(self, scroll_pos):
-		x = scroll_pos
-		pos = graphics.DrawText(self.canvas, self.font["font"], x, self.y, self.text_color, self.text)
-		h = self.font["size"]["height"]
-		for x in range(self.x):
-			graphics.DrawLine(self.canvas, x, self.y, x, self.y - h, self.bg_color)
-		for x in range(self.x + self.width, self.canvas.width):
-			graphics.DrawLine(self.canvas, x, self.y, x, self.y - h, self.bg_color)
-		return pos
+		if self.__text_should_scroll():
+			x = scroll_pos
+			pos = graphics.DrawText(self.canvas, self.font["font"], x, self.y, self.text_color, self.text)
+			h = self.font["size"]["height"]
+			for x in range(self.x):
+				graphics.DrawLine(self.canvas, x, self.y, x, self.y - h, self.bg_color)
+			for x in range(self.x + self.width, self.canvas.width):
+				graphics.DrawLine(self.canvas, x, self.y, x, self.y - h, self.bg_color)
+			return pos
+
+		else:
+			print "Centering Scrolling Text because it's too short"
+			graphics.DrawText(self.canvas, self.font["font"], self.__center_position(), self.y, self.text_color, self.text)
+			return 0
+
+	# Maybe the text is too short and we should just center it instead?
+	def __text_should_scroll(self):
+		return len(self.text) * self.font["size"]["width"] > self.width
+
+	def __center_position(self):
+		return center_text_position(self.text, abs(self.width/2) + self.x, self.font["size"]["width"])

--- a/renderers/status.py
+++ b/renderers/status.py
@@ -1,5 +1,6 @@
 from data.status import Status
 from renderers.teams import TeamsRenderer
+from renderers.scrollingtext import ScrollingText
 from rgbmatrix import graphics
 from utils import get_font, center_text_position
 
@@ -13,27 +14,42 @@ SUSPENDED_SHORTHAND = "Suspnd"
 CHALLENGE_SHORTHAND_32 = "Chalnge"
 
 class StatusRenderer:
-  def __init__(self, canvas, scoreboard, data):
+  def __init__(self, canvas, scoreboard, data, scroll_pos = 0):
     self.canvas = canvas
     self.scoreboard = scoreboard
     self.data = data
     self.colors = data.config.scoreboard_colors
+    self.bgcolor = self.colors.graphics_color("default.background")
+    self.scroll_pos = scroll_pos
 
   def render(self):
+    if self.scoreboard.get_text_for_reason():
+      text_len = self.__render_scroll_text()
+
     TeamsRenderer(self.canvas, self.scoreboard.home_team, self.scoreboard.away_team, self.data).render()
     self.__render_game_status()
 
+    if self.scoreboard.get_text_for_reason():
+      return text_len
+
   def __render_game_status(self):
-    color = self.colors.graphics_color("status_text")
+    color = self.colors.graphics_color("status.text")
     text = self.__get_text_for_status()
-    coords = self.data.config.layout.coords("status_text")
-    font = self.data.config.layout.font("status_text")
+    coords = self.data.config.layout.coords("status.text")
+    font = self.data.config.layout.font("status.text")
     text_x = center_text_position(text, coords["x"], font["size"]["width"])
     graphics.DrawText(self.canvas, font["font"], text_x, coords["y"], color, text)
 
+  def __render_scroll_text(self):
+    coords = self.data.config.layout.coords("status.scrolling_text")
+    font = self.data.config.layout.font("status.scrolling_text")
+    color = self.colors.graphics_color("status.scrolling_text")
+    scroll_text = "{}".format(self.scoreboard.get_text_for_reason())
+    return ScrollingText(self.canvas, coords["x"], coords["y"], coords["width"], font, color, self.bgcolor, scroll_text).render(self.scroll_pos)
+
   def __get_text_for_status(self):
     text = self.scoreboard.game_status
-    short_text = self.data.config.layout.coords("status_text")["short_text"]
+    short_text = self.data.config.layout.coords("status.text")["short_text"]
     if short_text:
       return self.__get_short_text(text)
     if text == Status.MANAGER_CHALLENGE:

--- a/renderers/status.py
+++ b/renderers/status.py
@@ -9,6 +9,7 @@ CHALLENGE_SHORTHAND = "Challenge"
 # Handle statuses that are too long for 32-wide boards.
 POSTPONED_SHORTHAND = 'Postpd'
 CANCELLED_SHORTHAND = "Cancl'd"
+SUSPENDED_SHORTHAND = "Suspnd"
 CHALLENGE_SHORTHAND_32 = "Chalnge"
 
 class StatusRenderer:
@@ -48,4 +49,6 @@ class StatusRenderer:
       return CANCELLED_SHORTHAND
     if text == Status.MANAGER_CHALLENGE:
       return CHALLENGE_SHORTHAND_32
+    if text == Status.SUSPENDED:
+      return SUSPENDED_SHORTHAND
     return text


### PR DESCRIPTION
Needs some more testing with other statuses. This worked great with the Suspended game but I'm not positive which status types get the `reason` or `notes` field populated.

This **should** cover any case where a `notes` attribute exists on an irregular status that would normally just display the status under the teams. If `notes` exists, it will scroll that. If it doesn't, we check for `reason` and scroll that instread. If neither exists, it should fall back on the normal status screen with no scrolling text.

Closes #165 
