### PR TITLE
Standings coords update

### DIFF
--- a/ledcoords/w128h32.json.example
+++ b/ledcoords/w128h32.json.example
@@ -147,7 +147,7 @@
   },
   "standings": {
     "offset": 8,
-    "height": 32,
+    "height": 30,
     "width": 128,
     "divider": {
       "x": 25
@@ -159,8 +159,11 @@
       "name": {
         "x": 1
       },
-      "stat": {
-        "x": 15
+      "record": {
+        "x": 64
+      },
+      "games_back": {
+        "x": 126
       }
     }
   },

--- a/ledcoords/w32h32.json.example
+++ b/ledcoords/w32h32.json.example
@@ -147,7 +147,7 @@
   },
   "standings": {
     "offset": 6,
-    "height": 32,
+    "height": 30,
     "width": 32,
     "divider": {
       "x": 13
@@ -159,8 +159,11 @@
       "name": {
         "x": 1
       },
-      "stat": {
+      "record": {
         "x": 15
+      },
+      "games_back": {
+        "x": 64
       }
     }
   },

--- a/ledcoords/w64h32.json.example
+++ b/ledcoords/w64h32.json.example
@@ -147,7 +147,7 @@
   },
   "standings": {
     "offset": 6,
-    "height": 32,
+    "height": 30,
     "width": 64,
     "divider": {
       "x": 13
@@ -159,8 +159,11 @@
       "name": {
         "x": 1
       },
-      "stat": {
-        "x": 15
+      "record": {
+        "x": 31
+      },
+      "games_back": {
+        "x": 64
       }
     }
   },

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import mlbgame
 import debug
 
 SCRIPT_NAME = "MLB LED Scoreboard"
-SCRIPT_VERSION = "1.6.1"
+SCRIPT_VERSION = "1.7.0"
 
 # Get supplied command line arguments
 args = args()


### PR DESCRIPTION
This is a small update to the standings renderer. It breaks up the record and games back into separate coords entries (the `stat` entry on 32x32 boards has been renamed to `record` for conformity sake). On wider screens, `record` is centered along the `x` coord while `games_back` is right aligned. 32x32 screens maintain exact coords since alignment isn't as much of an issue there.

Also redid the fill to take the `height` and `width` for standings into account. The default value for `height` has been changed to `30` to get rid of that annoying extra line of pixels on the bottom of the screen.