### PR TITLE
Fix statuses with text (specifically Review)

### DIFF
--- a/data/status.py
+++ b/data/status.py
@@ -38,7 +38,7 @@ class Status:
   def is_irregular(status):
     """Returns whether game is in an irregular state, such as delayed, postponed, cancelled,
     or in a challenge."""
-    return status in [Status.POSTPONED, Status.SUSPENDED, Status.DELAYED, Status.DELAYED_START, Status.CANCELLED, Status.MANAGER_CHALLENGE]
+    return status in [Status.POSTPONED, Status.SUSPENDED, Status.DELAYED, Status.DELAYED_START, Status.CANCELLED, Status.MANAGER_CHALLENGE, Status.REVIEW]
 
   @staticmethod
   def is_fresh(status):


### PR DESCRIPTION
A game froze up my rotation when it went into "Review" status. This adds the "Review" status to the list of irregular statuses so it can check for a reason text to scroll. Should prevent the freeze up next time.