### PR TITLE
Multiple teams and divisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A default `config.json.example` file is included for reference. Copy this file t
 
 ```
 "preferred":                           Options for team and division preference
-  "teams"                      String  Pick a team to display a game for. (This will accept an array in the future) Example: "Cubs"
+  "teams"                      Array   Pass an array of preferred teams. The first team in the list will be used as your 'favorite' team. Example: ["Cubs", "Brewers"]
   "divisions"                  String  Pick a division to display standings for when display_standings is true. (This will accept an array in the future) Example: "NL Central"
 
 "standings":                           Options for displaying standings for a division
@@ -112,6 +112,7 @@ A default `config.json.example` file is included for reference. Copy this file t
 "rotation":                            Options for rotation through the day's games
   "enabled"                    Bool    Rotate through each game of the day every 15 seconds.
   "scroll_until_finished"      Bool    If scrolling text takes longer than the rotation rate, wait to rotate until scrolling is done.
+  "only_preferred"             Bool    Only rotate through games in your preferred_teams list.
   "rates"                      Dict    Dictionary of Floats. Each type of screen can use a different rotation rate. Valid types: "live", "pregame", "final".
                                Float   A Float can be used to set all screen types to the same rotate rate.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A default `config.json.example` file is included for reference. Copy this file t
 ```
 "preferred":                           Options for team and division preference
   "teams"                      Array   Pass an array of preferred teams. The first team in the list will be used as your 'favorite' team. Example: ["Cubs", "Brewers"]
-  "divisions"                  String  Pick a division to display standings for when display_standings is true. (This will accept an array in the future) Example: "NL Central"
+  "divisions"                  Array   Pass an array of preferred divisions that will be rotated through in the order they are entered. Example: ["NL Central", "AL Central"]
 
 "standings":                           Options for displaying standings for a division
   "always_display"             Bool    Display standings for the provided preferred_divisions.

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,6 @@
 {
 	"preferred": {
-		"teams": "Cubs",
+		"teams": ["Cubs"],
 		"divisions": "NL Central"
 	},
 	"standings": {
@@ -11,6 +11,7 @@
 	"rotation": {
 		"enabled": true,
 		"scroll_until_finished": true,
+		"only_preferred": false,
 		"rates": {
 			"live": 15.0,
 			"final": 15.0,

--- a/config.json.example
+++ b/config.json.example
@@ -1,7 +1,7 @@
 {
 	"preferred": {
 		"teams": ["Cubs"],
-		"divisions": "NL Central"
+		"divisions": ["NL Central"]
 	},
 	"standings": {
 		"team_offday": false,

--- a/data/data.py
+++ b/data/data.py
@@ -72,7 +72,13 @@ class Data:
       try:
         current_day = self.day
         self.set_current_date()
-        self.games = mlbgame.day(self.year, self.month, self.day)
+
+        all_games = mlbgame.day(self.year, self.month, self.day)
+        if self.config.rotation_only_preferred:
+          self.games = self.__filter_list_of_games(all_games, self.config.preferred_teams)
+        else:
+          self.games = all_games
+
         if current_day != self.day:
           self.current_game_index = self.game_index_for_preferred_team()
         self.games_refresh_time = time.time()
@@ -142,9 +148,12 @@ class Data:
 
   def game_index_for_preferred_team(self):
     if self.config.preferred_teams:
-      return self.__game_index_for(self.config.preferred_teams)
+      return self.__game_index_for(self.config.preferred_teams[0])
     else:
       return 0
+
+  def __filter_list_of_games(self, games, teams):
+    return list(filter(lambda game: set(teams) & set([game.away_team, game.home_team]), games))
 
   def __game_index_for(self, team_name):
     game_idx = 0
@@ -156,7 +165,6 @@ class Data:
     if counter >= len(self.games):
       counter = 0
     return counter
-
 
   #
   # Offdays

--- a/data/data.py
+++ b/data/data.py
@@ -36,6 +36,7 @@ class Data:
 
     # What game do we want to start on?
     self.current_game_index = self.game_index_for_preferred_team()
+    self.current_division_index = 0
 
 
   #
@@ -130,11 +131,23 @@ class Data:
   # Standings
 
   def standings_for_preferred_division(self):
-    return self.__standings_for(self.config.preferred_divisions)
+    return self.__standings_for(self.config.preferred_divisions[0])
 
   def __standings_for(self, division_name):
     return next(division for division in self.standings.divisions if division.name == division_name)
 
+  def current_standings(self):
+    return self.__standings_for(self.config.preferred_divisions[self.current_division_index])
+
+  def advance_to_next_standings(self):
+    self.current_division_index = self.__next_division_index()
+    return self.current_standings()
+
+  def __next_division_index(self):
+    counter = self.current_division_index + 1
+    if counter >= len(self.config.preferred_divisions):
+      counter = 0
+    return counter
 
   #
   # Games

--- a/data/data.py
+++ b/data/data.py
@@ -184,7 +184,7 @@ class Data:
 
   def is_offday_for_preferred_team(self):
     if self.config.preferred_teams:
-      return not (next((i for i, game in enumerate(self.games) if self.config.preferred_teams in [game.away_team, game.home_team]), None))
+      return not (next((i for i, game in enumerate(self.games) if self.config.preferred_teams[0] in [game.away_team, game.home_team]), None))
     else:
       return True
 

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -12,6 +12,7 @@ DEFAULT_ROTATE_RATE = 15.0
 MINIMUM_ROTATE_RATE = 2.0
 DEFAULT_ROTATE_RATES = {"live": DEFAULT_ROTATE_RATE, "final": DEFAULT_ROTATE_RATE, "pregame": DEFAULT_ROTATE_RATE}
 DEFAULT_PREFERRED_TEAMS = ["Cubs"]
+DEFAULT_PREFERRED_DIVISIONS = ["NL Central"]
 
 class ScoreboardConfig:
   def __init__(self, filename_base, width, height):
@@ -56,8 +57,9 @@ class ScoreboardConfig:
     json = self.__get_colors("scoreboard")
     self.scoreboard_colors = Color(json)
 
-    # Check the preferred teams is a list or a string
+    # Check the preferred teams and divisions are a list or a string
     self.check_preferred_teams()
+    self.check_preferred_divisions()
 
     #Check the rotation_rates to make sure it's valid and not silly
     self.check_rotate_rates()
@@ -69,6 +71,15 @@ class ScoreboardConfig:
     if isinstance(self.preferred_teams, str):
       team = self.preferred_teams
       self.preferred_teams = [team]
+
+  def check_preferred_divisions(self):
+    if not isinstance(self.preferred_divisions, str) and not isinstance(self.preferred_divisions, list):
+      debug.warning("preferred_divisions should be an array of division names or a single division name string. Using default preferred_divisions, {}".format(DEFAULT_PREFERRED_DIVISIONS))
+      self.preferred_divisions = DEFAULT_PREFERRED_DIVISIONS
+    if isinstance(self.preferred_divisions, str):
+      division = self.preferred_divisions
+      self.preferred_divisions = [division]
+
 
   def check_rotate_rates(self):
     if isinstance(self.rotation_rates, dict) == False:

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -11,6 +11,7 @@ DEFAULT_SCROLLING_SPEED = 2
 DEFAULT_ROTATE_RATE = 15.0
 MINIMUM_ROTATE_RATE = 2.0
 DEFAULT_ROTATE_RATES = {"live": DEFAULT_ROTATE_RATE, "final": DEFAULT_ROTATE_RATE, "pregame": DEFAULT_ROTATE_RATE}
+DEFAULT_PREFERRED_TEAMS = ["Cubs"]
 
 class ScoreboardConfig:
   def __init__(self, filename_base, width, height):
@@ -29,6 +30,7 @@ class ScoreboardConfig:
     # Rotation
     self.rotation_enabled = json["rotation"]["enabled"]
     self.rotation_scroll_until_finished = json["rotation"]["scroll_until_finished"]
+    self.rotation_only_preferred = json["rotation"]["only_preferred"]
     self.rotation_rates = json["rotation"]["rates"]
     self.rotation_preferred_team_live_enabled = json["rotation"]["while_preferred_team_live"]["enabled"]
 
@@ -54,8 +56,19 @@ class ScoreboardConfig:
     json = self.__get_colors("scoreboard")
     self.scoreboard_colors = Color(json)
 
+    # Check the preferred teams is a list or a string
+    self.check_preferred_teams()
+
     #Check the rotation_rates to make sure it's valid and not silly
     self.check_rotate_rates()
+
+  def check_preferred_teams(self):
+    if not isinstance(self.preferred_teams, str) and not isinstance(self.preferred_teams, list):
+      debug.warning("preferred_teams should be an array of team names or a single team name string. Using default preferred_teams, {}".format(DEFAULT_PREFERRED_TEAMS))
+      self.preferred_teams = DEFAULT_PREFERRED_TEAMS
+    if isinstance(self.preferred_teams, str):
+      team = self.preferred_teams
+      self.preferred_teams = [team]
 
   def check_rotate_rates(self):
     if isinstance(self.rotation_rates, dict) == False:

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -91,7 +91,7 @@ class MainRenderer:
     if stay_on_preferred_team == False:
       return True
 
-    showing_preferred_team = self.data.config.preferred_teams in [overview.away_team_name, overview.home_team_name]
+    showing_preferred_team = self.data.config.preferred_teams[0] in [overview.away_team_name, overview.home_team_name]
     if showing_preferred_team and Status.is_live(overview.status):
       return False
 

--- a/renderers/standings.py
+++ b/renderers/standings.py
@@ -14,6 +14,7 @@ class StandingsRenderer:
     self.stat_color = self.colors.graphics_color("standings.stat")
     self.team_stat_color = self.colors.graphics_color("standings.team.stat")
     self.team_name_color = self.colors.graphics_color("standings.team.name")
+    self.rotating_stat = 'l'
 
   def render(self):
     self.__fill_bg()
@@ -40,7 +41,7 @@ class StandingsRenderer:
       graphics.DrawText(self.canvas, font["font"], coords["stat_title"]["x"], offset, self.stat_color, stat.upper())
       graphics.DrawLine(self.canvas, coords["divider"]["x"], 0, coords["divider"]["x"], coords["height"], self.divider_color)
 
-      for team in self.data.standings_for_preferred_division().teams:
+      for team in self.data.current_standings().teams:
         graphics.DrawLine(self.canvas, 0, offset, coords["width"], offset, self.divider_color)
 
         team_text = "{:3s}".format(team.team_abbrev)
@@ -54,7 +55,12 @@ class StandingsRenderer:
       time.sleep(5.0)
 
       self.__fill_bg()
-      stat = 'w' if stat == 'l' else 'l'
+
+      if stat == 'l':
+        self.data.advance_to_next_standings()
+        stat = 'w'
+      else:
+        stat = 'l'
 
   def __render_static_wide_standings(self):
     coords = self.data.config.layout.coords("standings")
@@ -63,7 +69,7 @@ class StandingsRenderer:
       offset = coords["offset"]
       graphics.DrawLine(self.canvas, coords["divider"]["x"], 0, coords["divider"]["x"], coords["height"], self.divider_color)
 
-      for team in self.data.standings_for_preferred_division().teams:
+      for team in self.data.current_standings().teams:
         graphics.DrawLine(self.canvas, 0, offset, coords["width"], offset, self.divider_color)
 
         team_text = team.team_abbrev
@@ -84,10 +90,12 @@ class StandingsRenderer:
         offset += coords["offset"]
 
       self.matrix.SwapOnVSync(self.canvas)
-      time.sleep(20.0)
+      time.sleep(10.0)
+      self.__fill_bg()
+      self.data.advance_to_next_standings()
 
   def __is_dumpster_fire(self):
-    return "comedy" in self.data.config.preferred_divisions.lower()
+    return "comedy" in self.data.config.preferred_divisions[self.data.current_division_index].lower()
 
   def __render_dumpster_fire(self):
     image_file = get_file("Assets/fire.jpg")

--- a/renderers/standings.py
+++ b/renderers/standings.py
@@ -14,7 +14,6 @@ class StandingsRenderer:
     self.stat_color = self.colors.graphics_color("standings.stat")
     self.team_stat_color = self.colors.graphics_color("standings.team.stat")
     self.team_name_color = self.colors.graphics_color("standings.team.name")
-    self.rotating_stat = 'l'
 
   def render(self):
     self.__fill_bg()


### PR DESCRIPTION
Adds the ability to use an array of strings as the `preferred_teams` and `preferred_divisions` in the config.

`preferred_divisions` will rotate through those divisions when displaying standings.
`preferred_teams` will use the first element as the "favorite" team and will act as it always has before this. A new option in `rotation` called `only_preferred` will limit the rotated games to only games that include teams in the `preferred_teams` list.

Closes #126 
Closes #113 