### PR TITLE
Fix a crash with the news ticker

### DIFF
--- a/data/headlines.py
+++ b/data/headlines.py
@@ -109,7 +109,10 @@ class Headlines:
 
     if self.include_countdowns:
       countdown_string = self.important_dates.next_important_date_string()
-      ticker = self.__add_string_to_ticker(ticker, countdown_string)
+
+      # If we get None back from this method, we don't have an important date coming soon
+      if countdown_string is not None:
+        ticker = self.__add_string_to_ticker(ticker, countdown_string)
 
     if self.feed_data != None:
       ticker = self.__add_string_to_ticker(ticker, "")

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import mlbgame
 import debug
 
 SCRIPT_NAME = "MLB LED Scoreboard"
-SCRIPT_VERSION = "3.2.0"
+SCRIPT_VERSION = "3.2.1"
 
 # Get supplied command line arguments
 args = args()


### PR DESCRIPTION
When an "important date" was too far away, the news ticker would crash. This should take care of that.

Fixes #252 