### PR TITLE
Add 24h time format option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requires a Raspberry PI and an LED board hooked up via the GPIO pins.
  * 64x32
  * 128x32
  * 128x64
- 
+
 **Boards not supported but on our radar - we welcome contributors!**
  * 64x64 - [#199](https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/issues/199)
 
@@ -151,6 +151,7 @@ A default `config.json.example` file is included for reference. Copy this file t
   "country"                    String  The ISO 3166 country code associated with the zipcode
   "metric_units"               Bool    Set true for celsius and meters/s. Set false for fahrenheit and miles per hour.
 
+"time_format"                  String  Sets the preferred hour format for displaying time. Accepted values are "12h" or "24h" depending on which you prefer.
 "end_of_day"                   String  A 24-hour time you wish to consider the end of the previous day before starting to display the current day's games. Uses local time from your pi.
 "full_team_names"              Bool    If true and on a 64-wide board, displays the full team name on the scoreboard instead of their abbreviation. This config option is ignored on 32-wide boards. Defaults to true when on a 64-wide board.
 "scrolling_speed"              Integer Supports an integer between 0 and 4. Sets how fast the scrolling text scrolls.

--- a/config.json.example
+++ b/config.json.example
@@ -37,6 +37,7 @@
 		"location": "Chicago,il,us",
 		"metric_units": false
 	},
+	"time_format": "12h",
 	"end_of_day": "00:00",
 	"full_team_names": true,
 	"scrolling_speed": 2,

--- a/data/data.py
+++ b/data/data.py
@@ -234,7 +234,7 @@ class Data:
 
   def print_overview_debug(self):
     debug.log("Overview Refreshed: {}".format(self.overview.id))
-    debug.log("Pre: {}".format(Pregame(self.overview)))
+    debug.log("Pre: {}".format(Pregame(self.overview, self.config.time_format)))
     debug.log("Live: {}".format(Scoreboard(self.overview)))
     debug.log("Final: {}".format(Final(self.current_game())))
 

--- a/data/pregame.py
+++ b/data/pregame.py
@@ -5,9 +5,10 @@ import pytz
 import tzlocal
 
 class Pregame:
-  def __init__(self, overview):
+  def __init__(self, overview, time_format):
     self.home_team = overview.home_name_abbrev
     self.away_team = overview.away_name_abbrev
+    self.time_format = time_format
 
     try:
       self.start_time = self.__convert_time(overview.time + overview.ampm)
@@ -45,12 +46,16 @@ class Pregame:
 
   def __convert_time(self, time):
     """Converts MLB's pregame times (Eastern) into the local time zone"""
+    time_str = "{}:%M".format(self.time_format)
+    if self.time_format == "%-I":
+      time_str += "%p"
+
     game_time_eastern = datetime.strptime(time, '%I:%M%p')
     now = datetime.now()
     game_time_eastern = game_time_eastern.replace(year=now.year, month=now.month, day=now.day)
     eastern_tz = pytz.timezone('America/New_York')
     game_time_eastern = eastern_tz.localize(game_time_eastern)
-    return game_time_eastern.astimezone(tzlocal.get_localzone()).strftime('%I:%M%p').lstrip('0')
+    return game_time_eastern.astimezone(tzlocal.get_localzone()).strftime(time_str)
 
   def __str__(self):
     s = "<{} {}> {} @ {}; {}; {} vs {}".format(

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -100,9 +100,7 @@ class ScoreboardConfig:
       self.preferred_divisions = [division]
 
   def check_time_format(self):
-    if self.time_format.lower() == "12h":
-      self.time_format = "%-I"
-    elif self.time_format.lower() == "24h":
+    if self.time_format.lower() == "24h":
       self.time_format = "%-H"
     else:
       self.time_format = "%-I"

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -52,6 +52,7 @@ class ScoreboardConfig:
     self.weather_metric_units = json["weather"]["metric_units"]
 
     # Misc config options
+    self.time_format = json["time_format"]
     self.end_of_day = json["end_of_day"]
     self.full_team_names = json["full_team_names"]
     self.debug = json["debug"]
@@ -75,6 +76,7 @@ class ScoreboardConfig:
     self.scoreboard_colors = Color(json)
 
     # Check the preferred teams and divisions are a list or a string
+    self.check_time_format()
     self.check_preferred_teams()
     self.check_preferred_divisions()
 
@@ -97,6 +99,13 @@ class ScoreboardConfig:
       division = self.preferred_divisions
       self.preferred_divisions = [division]
 
+  def check_time_format(self):
+    if self.time_format.lower() == "12h":
+      self.time_format = "%-I"
+    elif self.time_format.lower() == "24h":
+      self.time_format = "%-H"
+    else:
+      self.time_format = "%-I"
 
   def check_rotate_rates(self):
     if isinstance(self.rotation_rates, dict) == False:

--- a/debug.py
+++ b/debug.py
@@ -3,10 +3,14 @@ import time
 import sys
 
 debug_enabled = False
+time_format = "%H"
 
 def set_debug_status(config):
 	global debug_enabled
 	debug_enabled = config.debug
+
+	global time_format
+	time_format = config.time_format
 
 def __debugprint(text):
 	print(text)
@@ -26,4 +30,4 @@ def info(text):
 	__debugprint("INFO ({}): {}".format(__timestamp(), text))
 
 def __timestamp():
-	return time.strftime("%H:%M:%S", time.localtime())
+	return time.strftime("{}:%M:%S".format(time_format), time.localtime())

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -166,7 +166,7 @@ class MainRenderer:
     if Status.is_pregame(overview.status):
       scoreboard = Scoreboard(overview)
       scroll_max_x = self.__max_scroll_x(self.data.config.layout.coords("pregame.scrolling_text"))
-      pregame = Pregame(overview)
+      pregame = Pregame(overview, self.data.config.time_format)
       renderer = PregameRenderer(self.canvas, pregame, scoreboard, self.data, self.scrolling_text_pos)
       self.__update_scrolling_text_pos(renderer.render())
 

--- a/renderers/offday.py
+++ b/renderers/offday.py
@@ -27,7 +27,10 @@ class OffdayRenderer:
     return text_len
 
   def __render_clock(self):
-    time_text = time.strftime("%-I:%M%p")
+    time_format_str = "{}:%M".format(self.data.config.time_format)
+    if self.data.config.time_format == "%-I":
+      time_format_str += "%p"
+    time_text = time.strftime(time_format_str)
     coords = self.layout.coords("offday.time")
     font = self.layout.font("offday.time")
     color = self.colors.graphics_color("offday.time")


### PR DESCRIPTION
Added the `"time_format"` option to the config file so you can specify `"12h"` or `"24h"` for your preferred time output format.

Closes #253 