### PR TITLE
Fix an issue with scrolling screens when there isn't any reason text

### DIFF
--- a/renderers/status.py
+++ b/renderers/status.py
@@ -30,8 +30,9 @@ class StatusRenderer:
     TeamsRenderer(self.canvas, self.scoreboard.home_team, self.scoreboard.away_team, self.data).render()
     self.__render_game_status()
 
-    if self.scoreboard.get_text_for_reason():
-      return text_len
+    if self.scoreboard.get_text_for_reason() is None:
+      return 0
+    return text_len
 
   def __render_game_status(self):
     color = self.colors.graphics_color("status.text")


### PR DESCRIPTION
This may fix #261 (and various other scoreboard hangs that haven't been reported here but mentioned on our discord). We're always expecting to get a number returned from this method for updating our scrolling position so we should be returning 0 if there's nothing to scroll.