### PR TITLE
Update submodule to latest master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mlb-led-scoreboard
 An LED scoreboard for Major League Baseball. Displays a live scoreboard for your team's game on that day.
 
-Requires a Raspberry PI and an LED board hooked up via the GPIO pins.
+Requires a Raspberry Pi and an LED board hooked up via the GPIO pins.
 
 [![Join Slack](https://img.shields.io/badge/slack-join-blue.svg)](https://mlb-led-scoreboard.herokuapp.com/)
 
@@ -13,6 +13,9 @@ Requires a Raspberry PI and an LED board hooked up via the GPIO pins.
  * 128x64
 
 If you'd like to see support for another set of board dimensions, file an issue!
+
+**Pi's with known issues**
+ * Raspberry Pi Zero has had numerous reports of slowness and unreliabilty during installation and running the software.
 
 ## Table of Contents
 * [Features](#features)

--- a/data/data.py
+++ b/data/data.py
@@ -76,7 +76,10 @@ class Data:
 
   def refresh_standings(self):
     try:
-      self.standings = mlbgame.standings()
+      if self.config.demo_date:
+        self.standings = mlbgame.standings(datetime(self.year, self.month, self.day, 23, 59, 0, 0))
+      else:
+        self.standings = mlbgame.standings()
     except:
       debug.error("Failed to refresh standings.")
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import mlbgame
 import debug
 
 SCRIPT_NAME = "MLB LED Scoreboard"
-SCRIPT_VERSION = "3.5.0"
+SCRIPT_VERSION = "3.5.1"
 
 # Get supplied command line arguments
 args = args()

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -76,8 +76,10 @@ class MainRenderer:
   def __render_standings(self):
     try:
       StandingsRenderer(self.matrix, self.canvas, self.data).render()
-    except:
+    except Exception as ex:
       # Out of season off days don't always return standings so fall back on the offday renderer
+      debug.error("Could not render standings.  Falling back to off day.")
+      debug.error("{}: {}".format(type(ex).__name__, ex.args))
       self.__render_offday()
 
   # Renders a game screen based on it's status

--- a/renderers/standings.py
+++ b/renderers/standings.py
@@ -49,9 +49,9 @@ class StandingsRenderer:
         stat_text = str(getattr(team, stat))
         graphics.DrawText(self.canvas, font["font"], coords["team"]["name"]["x"], offset, self.team_name_color, team_text)
         graphics.DrawText(self.canvas, font["font"], coords["team"]["record"]["x"], offset, self.team_stat_color, stat_text)
-
+      
         offset += coords["offset"]
-
+      
       self.matrix.SwapOnVSync(self.canvas)
       time.sleep(5.0)
 
@@ -89,11 +89,21 @@ class StandingsRenderer:
         graphics.DrawText(self.canvas, font["font"], gb_text_x, offset, self.team_stat_color, gb_text)
 
         offset += coords["offset"]
+      
+      self.__fill_standings_footer()
 
       self.matrix.SwapOnVSync(self.canvas)
       time.sleep(10.0)
       self.__fill_bg()
       self.data.advance_to_next_standings()
+
+  def __fill_standings_footer(self):
+    coords = self.data.config.layout.coords("standings")
+    graphics.DrawLine(self.canvas, 0, coords["height"], coords["width"], coords["height"], self.bg_color)
+    graphics.DrawLine(self.canvas, coords["divider"]["x"], 0, coords["divider"]["x"], coords["height"], self.divider_color)
+    graphics.DrawLine(self.canvas, 0, coords["height"]+1, coords["width"], coords["height"]+1, self.bg_color)
+    graphics.DrawLine(self.canvas, coords["divider"]["x"], 0, coords["divider"]["x"], coords["height"]+1, self.divider_color)
+    
 
   def __is_dumpster_fire(self):
     return "comedy" in self.data.config.preferred_divisions[self.data.current_division_index].lower()


### PR DESCRIPTION
Closes #290.

Updates the `rpi-rgp-led-matrix` submodule to latest master to provide better support for Raspberry Pi 4.

This should continue to work for Pi 3 and under without a reinstall. Re-running the installer with `sh install.sh` should now grab the latest in the driver submodule before installing it, and I've tested this to correctly update on an install with the old [submodule @ 36a4633](https://github.com/hzeller/rpi-rgb-led-matrix/tree/36a46331e300764a79a4ba45d723270e8cceedda).