### PR TITLE
293/fix broken standings

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -2,8 +2,7 @@ from datetime import datetime, timedelta
 from final import Final
 from pregame import Pregame
 from scoreboard import Scoreboard
-# Import a handler for the standings data to minimize impact to rest of the codebase
-from standings import *
+from standings import Standings, Division, Team
 from status import Status
 from inning import Inning
 from weather import Weather
@@ -77,16 +76,7 @@ class Data:
   # mlbgame refresh
 
   def refresh_standings(self):
-    # TODO: This function is a workaround for MLB and mlbgame package no longer supporting GameDay XML API
-    # Old code is left for reference only!
-
-
     try:
-      # if self.config.demo_date:
-        # self.standings = mlbgame.standings(datetime(self.year, self.month, self.day, 23, 59, 
-      # else:
-        # self.standings = mlbgame.standings()
-
       self.standings = Standings.fetch(self.year, self.month, self.day)
     except:
       debug.error("Failed to refresh standings.")

--- a/data/data.py
+++ b/data/data.py
@@ -2,6 +2,8 @@ from datetime import datetime, timedelta
 from final import Final
 from pregame import Pregame
 from scoreboard import Scoreboard
+# Import a handler for the standings data to minimize impact to rest of the codebase
+from standings import *
 from status import Status
 from inning import Inning
 from weather import Weather
@@ -75,11 +77,17 @@ class Data:
   # mlbgame refresh
 
   def refresh_standings(self):
+    # TODO: This function is a workaround for MLB and mlbgame package no longer supporting GameDay XML API
+    # Old code is left for reference only!
+
+
     try:
-      if self.config.demo_date:
-        self.standings = mlbgame.standings(datetime(self.year, self.month, self.day, 23, 59, 0, 0))
-      else:
-        self.standings = mlbgame.standings()
+      # if self.config.demo_date:
+        # self.standings = mlbgame.standings(datetime(self.year, self.month, self.day, 23, 59, 
+      # else:
+        # self.standings = mlbgame.standings()
+
+      self.standings = Standings.fetch(self.year, self.month, self.day)
     except:
       debug.error("Failed to refresh standings.")
 

--- a/data/standings.py
+++ b/data/standings.py
@@ -1,0 +1,100 @@
+import requests
+import re
+
+class Standings:
+    __URL = 'https://statsapi.mlb.com/api/v1/standings?season={year}&leagueId=103,104&date={month:0>2}/{day:0>2}/{year}&division=all'
+
+    @classmethod
+    def fetch(cls, year, month, day):
+        standings_data = requests.get(Standings.__URL.format(day=day, month=month, year=year))
+
+        if standings_data.status_code == 200:
+            return Standings(standings_data.json())
+        else:
+            raise Exception('Could not fetch standings.')
+
+    def __init__(self, data):
+        self.__data = data
+        self.divisions = self.__fetch_divisions()
+
+    def __fetch_divisions(self):
+        return [Division(division_data) for division_data in self.__data['records']]
+        
+
+class Division:
+    def __init__(self, data):
+        self.__data = data
+        self.id = self.__data['division']['id']
+        self.name = self.__name()
+        self.teams = self.__teams()
+
+    def __name(self):
+        division_records = self.__data['teamRecords'][0]['records']['divisionRecords']
+        full_name = [datum['division']['name'] for datum in division_records if datum['division']['id'] == self.id][0]
+        
+        # Use some regex to fix the division full name to what the config expects
+        return re.sub(r'(ational|merican)\sLeague', 'L', full_name)
+
+    def __teams(self):
+        return [Team(team_data, self.id) for team_data in self.__data['teamRecords']]
+
+
+class Team:
+    __TEAM_ABBREVIATIONS = {
+        'Arizona Diamondbacks': 'ARI',
+        'Atlanta Braves': 'ATL',
+        'Baltimore Orioles': 'BAL',
+        'Boston Red Sox': 'BOS',
+        'Chicago Cubs': 'CHC',
+        'Chicago White Sox': 'CHW',
+        'Cincinnati Reds': 'CIN',
+        'Cleveland Indians': 'CLE',
+        'Colorado Rockies': 'COL',
+        'Detroit Tigers': 'DET',
+        'Florida Marlins': 'FLA',
+        'Houston Astros': 'HOU',
+        'Kansas City Royals': 'KAN',
+        'Los Angeles Angels': 'LAA',
+        'Los Angeles Dodgers': 'LAD',
+        'Miami Marlins': 'MIA',
+        'Milwaukee Brewers': 'MIL',
+        'Minnesota Twins': 'MIN',
+        'New York Mets': 'NYM',
+        'New York Yankees': 'NYY',
+        'Oakland Athletics': 'OAK',
+        'Philadelphia Phillies': 'PHI',
+        'Pittsburgh Pirates': 'PIT',
+        'San Diego Padres': 'SD',
+        'San Francisco Giants': 'SF',
+        'Seattle Mariners': 'SEA',
+        'St. Louis Cardinals': 'STL',
+        'Tampa Bay Rays': 'TB',
+        'Texas Rangers': 'TEX',
+        'Toronto Blue Jays': 'TOR',
+        'Washington Nationals': 'WAS',
+    }
+
+    def __init__(self, data, division_id):
+        self.__data = data
+        self.__division_standings = self.__find_division(division_id)
+        self.name = self.__name()
+        self.team_abbrev = self.__TEAM_ABBREVIATIONS[self.name]
+        self.w = self.__parse_wins()
+        self.l = self.__parse_losses()
+        self.gb = self.__data['divisionGamesBack']
+
+    def __find_division(self, division_id):
+        for record in self.__data['records']['divisionRecords']:
+            if record['division']['id'] == division_id:
+                return record
+
+        raise Exception('Could not find division record.')
+
+    def __name(self):
+        return self.__data['team']['name']
+
+    def __parse_wins(self):
+        return self.__division_standings['wins']
+
+    def __parse_losses(self):
+        return self.__division_standings['losses']

--- a/data/standings.py
+++ b/data/standings.py
@@ -2,11 +2,12 @@ import requests
 import re
 
 class Standings:
-    __URL = 'https://statsapi.mlb.com/api/v1/standings?season={year}&leagueId=103,104&date={month:0>2}/{day:0>2}/{year}&division=all'
+    __URL = 'https://statsapi.mlb.com/api/v1/standings?season={year}&leagueId={league_id}&date={month:0>2}/{day:0>2}/{year}&division=all'
+    __LEAGUE_ID = '103,104'
 
     @classmethod
     def fetch(cls, year, month, day):
-        standings_data = requests.get(Standings.__URL.format(day=day, month=month, year=year))
+        standings_data = requests.get(Standings.__URL.format(day=day, month=month, year=year, league_id=Standings.__LEAGUE_ID))
 
         if standings_data.status_code == 200:
             return Standings(standings_data.json())
@@ -98,3 +99,9 @@ class Team:
 
     def __parse_losses(self):
         return self.__division_standings['losses']
+
+if __name__ == '__main__':
+    standings = Standings.fetch(2020, 7, 25)
+
+    import pdb
+    pdb.set_trace()

--- a/data/standings.py
+++ b/data/standings.py
@@ -2,12 +2,14 @@ import requests
 import re
 
 class Standings:
-    __URL = 'https://statsapi.mlb.com/api/v1/standings?season={year}&leagueId={league_id}&date={month:0>2}/{day:0>2}/{year}&division=all'
-    __LEAGUE_ID = '103,104'
+    __URL = 'https://statsapi.mlb.com/api/v1/standings?season={year}&leagueId={league_ids}&date={month:0>2}/{day:0>2}/{year}&division=all'
+    AL_LEAGUE_ID = '103'
+    NL_LEAGUE_ID = '104'
+    __LEAGUE_IDS = ','.join([AL_LEAGUE_ID, NL_LEAGUE_ID])
 
     @classmethod
     def fetch(cls, year, month, day):
-        standings_data = requests.get(Standings.__URL.format(day=day, month=month, year=year, league_id=Standings.__LEAGUE_ID))
+        standings_data = requests.get(Standings.__URL.format(day=day, month=month, year=year, league_ids=Standings.__LEAGUE_IDS))
 
         if standings_data.status_code == 200:
             return Standings(standings_data.json())
@@ -99,9 +101,3 @@ class Team:
 
     def __parse_losses(self):
         return self.__division_standings['losses']
-
-if __name__ == '__main__':
-    standings = Standings.fetch(2020, 7, 25)
-
-    import pdb
-    pdb.set_trace()


### PR DESCRIPTION
Should partially address [#293] to get standings to display without having to make a major change to how data is handled. This PR bypasses the old XML API to use MLB's new StatsAPI.

There's a new API wrapper designed to mimic the old `mlbgame` version in `data/standings`. Right now it hooks in directly to the old code used so it shouldn't break anything. If the standings fail to render (as they already are), it should fallback to the offday renderer.