### PR TITLE
[WIP] Update scoreboard for Python 3 compatibility

### DIFF
--- a/data/data.py
+++ b/data/data.py
@@ -8,7 +8,7 @@ from data.inning import Inning
 from data.weather import Weather
 from data.headlines import Headlines
 import urllib
-import data.layout
+import data.layout as layout
 import mlbgame
 import debug
 import time

--- a/data/headlines.py
+++ b/data/headlines.py
@@ -97,7 +97,7 @@ class Headlines:
             debug.log("Fetching {}".format(url))
             f = feedparser.parse(url)
             try:
-              title = f.feed.title.encode("ascii", "ignore")
+              title = f.feed.title
               debug.log("Fetched feed '{}' with {} entries.".format(title, len(f.entries)))
               feeds.append(f)
             except AttributeError:
@@ -136,13 +136,13 @@ class Headlines:
 
   def __strings_for_feed(self, feed, max_entries):
     spaces = " " * HEADLINE_SPACER_SIZE
-    title = feed.feed.title.encode("ascii", "ignore")
+    title = feed.feed.title
     headlines = ""
 
     for idx, entry in enumerate(feed.entries):
       if idx < max_entries:
         h = HTMLParser()
-        text = h.unescape(entry.title.encode("ascii", "ignore"))
+        text = h.unescape(entry.title)
         headlines += text + spaces
     return title + spaces + headlines
 

--- a/data/headlines.py
+++ b/data/headlines.py
@@ -2,7 +2,7 @@ import debug
 import time
 import feedparser
 from datetime import datetime
-from dates import Dates
+from data.dates import Dates
 
 try:
   from HTMLParser import HTMLParser

--- a/data/scoreboard.py
+++ b/data/scoreboard.py
@@ -1,8 +1,8 @@
-from bases import Bases
-from inning import Inning
-from pitches import Pitches
-from outs import Outs
-from team import Team
+from data.bases import Bases
+from data.inning import Inning
+from data.pitches import Pitches
+from data.outs import Outs
+from data.team import Team
 import datetime
 import debug
 

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -1,6 +1,6 @@
 from utils import get_file, deep_update
-from layout import Layout
-from color import Color
+from data.layout import Layout
+from data.color import Color
 import json
 import os
 import sys

--- a/data/status.py
+++ b/data/status.py
@@ -1,4 +1,4 @@
-from inning import Inning
+from data.inning import Inning
 
 class Status:
 

--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,11 @@ cd bindings
 sudo python3 -m pip install -e python/
 cd ../../
 echo "Installing required dependencies. This may take some time (10-20 minutes-ish)..."
-git reset --hard
-git checkout master
-git fetch origin --prune
-git pull
+# TODO: Revert this. Don't update scoreboard to master while testing!
+# git reset --hard
+# git checkout master
+# git fetch origin --prune
+# git pull
 sudo apt-get install libxml2-dev libxslt-dev -y
 sudo python3 -m pip install pytz tzlocal "feedparser<6.0.0" pyowm
 sudo python3 -m pip uninstall -y mlbgame

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 cd matrix
 echo "Running rgbmatrix installation..."
-sudo apt-get update && sudo apt-get install python2.7-dev python-pillow -y
-make build-python
-sudo make install-python
+sudo apt-get update && sudo apt-get install python3-dev python3-pillow -y
+make build-python PYTHON=$(which python3)
+sudo make install-python PYTHON=$(which python3)
 cd bindings
-sudo pip install -e python/
+sudo python3 -m pip install -e python/
 cd ../../
 echo "Installing required dependencies. This may take some time (10-20 minutes-ish)..."
 git reset --hard
 git checkout master
 git fetch origin --prune
 git pull
-sudo apt-get install libxml2-dev libxslt-dev
-sudo pip install pytz tzlocal feedparser pyowm
-sudo pip uninstall -y mlbgame
-sudo pip install git+git://github.com/ajbowler/mlbgame.git@#egg=mlbgame
+sudo apt-get install libxml2-dev libxslt-dev -y
+sudo python3 -m pip install pytz tzlocal "feedparser<6.0.0" pyowm
+sudo python3 -m pip uninstall -y mlbgame
+sudo python3 -m pip install git+git://github.com/ajbowler/mlbgame.git@#egg=mlbgame
 make
 echo "If you didn't see any errors above, everything should be installed!"
 if [ -n "$1" ]; then

--- a/renderers/bases.py
+++ b/renderers/bases.py
@@ -43,7 +43,7 @@ class BasesRenderer:
   def __render_baserunner(self, base, color):
     x, y = (base["x"], base["y"])
     size = base["size"]
-    half = abs(size/2)
+    half = abs(int(size/2))
     for offset in range(1, half+1):
       graphics.DrawLine(self.canvas, x + half - offset, y + size - offset, x + half + offset, y + size - offset, color)
       graphics.DrawLine(self.canvas, x + half - offset, y + offset, x + half + offset, y + offset, color)


### PR DESCRIPTION
This is a work-in-progress PR to facilitate testing Python 3 compatibility with `mlb-led-scoreboard`. Will address #300 when completed.

Users wishing to upgrade to running the Python 3 upgrade should first check that Python 3.5 or greater is installed:

```bash
python3 --version

# should be 3.5.x or greater
```

Next, checkout this WIP PR branch with the following:

```bash
git fetch origin pull/304/head:python3-update && git checkout python3-update
```

Run the scoreboard installer:

```bash
sh install.sh
```

For existing users, select "No" when prompted to create a new config -- a `config.json` file should already be present and compatible with these changes. **Note**: for test purposes, it would be helpful to set `debug: true` in your config.

Finally, run the board with options:

```bash
# Runs the board and stores the log file for later use
(sudo python3 main.py { YOUR OPTIONS }) %> debug_log.log

# If you want to see the debug text, in a new terminal:
tail -f debug_log.log
```

If you would rather use the `python` instead of `python3` command:

```bash
echo 'alias "python"=python3' >> ~/.bash_aliases
```

---

Once (if?) this PR is merged with `master`, most of these steps will be obsoleted as the `install.sh` script installs from latest `master` branch.