### PR TITLE
pin feedparser to <6.0.0

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ git checkout master
 git fetch origin --prune
 git pull
 sudo apt-get install libxml2-dev libxslt-dev
-sudo pip install pytz tzlocal feedparser pyowm
+sudo pip install pytz tzlocal "feedparser<6.0.0" pyowm
 sudo pip uninstall -y mlbgame
 sudo pip install git+git://github.com/ajbowler/mlbgame.git@#egg=mlbgame
 make


### PR DESCRIPTION
feedparser 6.0.0 no longer supports python2. pinning to version < 6 until master is compatible with python3.

would resolve #299 