### PR TITLE
Refactor standings module for correct win/loss record

### DIFF
--- a/data/standings.py
+++ b/data/standings.py
@@ -79,25 +79,17 @@ class Team:
 
     def __init__(self, data, division_id):
         self.__data = data
-        self.__division_standings = self.__find_division(division_id)
         self.name = self.__name()
         self.team_abbrev = self.__TEAM_ABBREVIATIONS[self.name]
         self.w = self.__parse_wins()
         self.l = self.__parse_losses()
         self.gb = self.__data['divisionGamesBack']
 
-    def __find_division(self, division_id):
-        for record in self.__data['records']['divisionRecords']:
-            if record['division']['id'] == division_id:
-                return record
-
-        raise Exception('Could not find division record.')
-
     def __name(self):
         return self.__data['team']['name']
 
     def __parse_wins(self):
-        return self.__division_standings['wins']
+        return self.__data['wins']
 
     def __parse_losses(self):
-        return self.__division_standings['losses']
+        return self.__data['losses']


### PR DESCRIPTION
Addresses #320

Same test from issue, using new implementation:

```python
if __name__ == '__main__':
    standings = Standings.fetch(2021, 4, 14)

    for division in standings.divisions:

        print('-------')
        print(division.name)
        print('-------')

        for team in division.teams:
            team_string = '{name} (W: {w}, L: {l})'.format(name = team.name, w = team.w, l = team.l)

            print(team_string)

        print('\n')
```

```
-------
AL West
-------
Los Angeles Angels (W: 7, L: 5)
Houston Astros (W: 6, L: 5)
Seattle Mariners (W: 6, L: 5)
Oakland Athletics (W: 5, L: 7)
Texas Rangers (W: 4, L: 7)


-------
AL East
-------
Boston Red Sox (W: 9, L: 3)
Toronto Blue Jays (W: 6, L: 6)
Baltimore Orioles (W: 5, L: 6)
Tampa Bay Rays (W: 5, L: 6)
New York Yankees (W: 5, L: 7)


-------
AL Central
-------
Cleveland Indians (W: 6, L: 4)
Kansas City Royals (W: 6, L: 4)
Chicago White Sox (W: 5, L: 6)
Detroit Tigers (W: 5, L: 6)
Minnesota Twins (W: 5, L: 7)


-------
NL Central
-------
Cincinnati Reds (W: 7, L: 5)
Milwaukee Brewers (W: 7, L: 5)
St. Louis Cardinals (W: 6, L: 6)
Chicago Cubs (W: 5, L: 7)
Pittsburgh Pirates (W: 4, L: 7)


-------
NL West
-------
Los Angeles Dodgers (W: 9, L: 2)
San Diego Padres (W: 8, L: 4)
San Francisco Giants (W: 8, L: 4)
Arizona Diamondbacks (W: 4, L: 8)
Colorado Rockies (W: 3, L: 8)


-------
NL East
-------
New York Mets (W: 4, L: 3)
Philadelphia Phillies (W: 6, L: 5)
Miami Marlins (W: 4, L: 6)
Atlanta Braves (W: 4, L: 7)
Washington Nationals (W: 3, L: 6)
```