### PR TITLE
Allow StatusRenderer to support multiple text scrolling

### DIFF
--- a/renderers/main.py
+++ b/renderers/main.py
@@ -22,6 +22,7 @@ class MainRenderer:
     self.data = data
     self.canvas = matrix.CreateFrameCanvas()
     self.scrolling_text_pos = self.canvas.width
+    self.scrolling_status_pos = self.canvas.width
     self.scrolling_finished = False
     self.starttime = time.time()
 
@@ -181,14 +182,20 @@ class MainRenderer:
       self.__update_scrolling_text_pos(renderer.render())
 
     # Draw the scoreboar renderer
-    elif Status.is_irregular(overview.status):
+    elif True: # Status.is_irregular(overview.status):
       scoreboard = Scoreboard(overview)
       if scoreboard.get_text_for_reason():
         scroll_max_x = self.__max_scroll_x(self.data.config.layout.coords("status.scrolling_text"))
-        renderer = StatusRenderer(self.canvas, scoreboard, self.data, self.scrolling_text_pos)
-        self.__update_scrolling_text_pos(renderer.render())
+        renderer = StatusRenderer(self.canvas, scoreboard, self.data, self.scrolling_text_pos, self.scrolling_status_pos)
+        scrolling_text_pos, status_text_pos = renderer.render()
+
+        self.__update_scrolling_status_pos(status_text_pos)
+        self.__update_scrolling_text_pos(scrolling_text_pos)
       else:
-        StatusRenderer(self.canvas, scoreboard, self.data).render()
+        renderer = StatusRenderer(self.canvas, scoreboard, self.data, status_scroll_pos = self.scrolling_status_pos)
+        _scrolling_text_pos, status_text_pos = renderer.render()
+
+        self.__update_scrolling_status_pos(status_text_pos)
     else:
       scoreboard = Scoreboard(overview)
       ScoreboardRenderer(self.canvas, scoreboard, self.data).render()
@@ -209,3 +216,11 @@ class MainRenderer:
       self.scrolling_text_pos = self.canvas.width
     else:
       self.scrolling_text_pos = pos_after_scroll
+
+  def __update_scrolling_status_pos(self, new_pos):
+    """Updates the position of the status text."""
+    pos_after_scroll = self.scrolling_status_pos - 1
+    if pos_after_scroll + new_pos < 0:
+      self.scrolling_status_pos = self.canvas.width
+    else:
+      self.scrolling_status_pos = pos_after_scroll

--- a/renderers/status.py
+++ b/renderers/status.py
@@ -16,25 +16,26 @@ CHALLENGE_SHORTHAND_32 = "Chalnge"
 UMPIRE_REVIEW_SHORTHAND = "Review"
 
 class StatusRenderer:
-  def __init__(self, canvas, scoreboard, data, scroll_pos = 0):
+  def __init__(self, canvas, scoreboard, data, scroll_pos = 0, status_scroll_pos = 0):
     self.canvas = canvas
     self.scoreboard = scoreboard
     self.data = data
     self.colors = data.config.scoreboard_colors
     self.bgcolor = self.colors.graphics_color("default.background")
     self.scroll_pos = scroll_pos
+    self.status_scroll_pos = status_scroll_pos
 
   def render(self):
     if self.scoreboard.get_text_for_reason():
-      text_len = self.__render_scroll_text()
+      scrolling_text_len = self.__render_scroll_text()
+    else:
+      scrolling_text_len = 0
 
     TeamsRenderer(self.canvas, self.scoreboard.home_team, self.scoreboard.away_team, self.data).render()
-    self.__render_game_status()
+    status_text_len = self.__render_game_status()
 
-    if self.scoreboard.get_text_for_reason() is None:
-      return 0
     NetworkErrorRenderer(self.canvas, self.data).render()
-    return text_len
+    return (scrolling_text_len, status_text_len)
 
   def __render_game_status(self):
     color = self.colors.graphics_color("status.text")
@@ -42,7 +43,12 @@ class StatusRenderer:
     coords = self.data.config.layout.coords("status.text")
     font = self.data.config.layout.font("status.text")
     text_x = center_text_position(text, coords["x"], font["size"]["width"])
-    graphics.DrawText(self.canvas, font["font"], text_x, coords["y"], color, text)
+
+    if self.__text_should_scroll(text, font, text_x):
+      graphics.DrawText(self.canvas, font["font"], text_x, coords["y"], color, text)
+      return 0
+    else:
+      return ScrollingText(self.canvas, 0, coords["y"], self.canvas.width, font, color, self.bgcolor, text).render(self.status_scroll_pos)
 
   def __render_scroll_text(self):
     coords = self.data.config.layout.coords("status.scrolling_text")
@@ -76,3 +82,6 @@ class StatusRenderer:
     if "suspended" in text.lower():
       return SUSPENDED_SHORTHAND
     return text
+
+  def __text_should_scroll(self, text, font, x_offset):
+    return len(text) * font["size"]["width"] + x_offset <= self.canvas.width


### PR DESCRIPTION
Addresses #303 & #258 for scrolling status text.

This _should_ work on all board sizes since it relies on canvas width (tested on 64x32). Might need to add to the `ledcoords` config to customize width of the scroll?

![scrolling-status](https://user-images.githubusercontent.com/46663285/117231535-6186a300-aded-11eb-97ea-1ef867215ca2.gif)

