### PR TITLE
Add support for rotating preferred divisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,8 @@ A default `config.json.example` file is included for reference. Copy this file t
 "rotation":                            Options for rotation through the day's games
   "enabled"                    Bool    Rotate through each game of the day every 15 seconds.
   "scroll_until_finished"      Bool    If scrolling text takes longer than the rotation rate, wait to rotate until scrolling is done.
-  "only_preferred"             Bool    Only rotate through games in your preferred_teams list.
+  "only_preferred_teams"       Bool    Only rotate through games in your preferred_teams list (supercedes the only_preferred_divisions setting).
+  "only_preferred_divisions"   Bool    Only rotate through games in your preferred_divisions list.
   "rates"                      Dict    Dictionary of Floats. Each type of screen can use a different rotation rate. Valid types: "live", "pregame", "final".
                                Float   A Float can be used to set all screen types to the same rotate rate.
 

--- a/config.json.example
+++ b/config.json.example
@@ -21,7 +21,8 @@
 	"rotation": {
 		"enabled": true,
 		"scroll_until_finished": true,
-		"only_preferred": false,
+		"only_preferred_teams": false,
+		"only_preferred_divisions": true,
 		"rates": {
 			"live": 15.0,
 			"final": 15.0,

--- a/data/data.py
+++ b/data/data.py
@@ -31,12 +31,12 @@ class Data:
     # Flag to determine when to refresh data
     self.needs_refresh = True
 
-    # Fetch the games for today
-    self.refresh_games()
-
     # Fetch all standings data for today
     # (Good to have in case we add a standings screen while rotating scores)
     self.refresh_standings()
+
+    # Fetch the games for today
+    self.refresh_games()
 
     # What game do we want to start on?
     self.current_game_index = self.game_index_for_preferred_team()
@@ -91,8 +91,10 @@ class Data:
         self.set_current_date()
 
         all_games = mlbgame.day(self.year, self.month, self.day)
-        if self.config.rotation_only_preferred:
+        if self.config.rotation_only_preferred_teams:
           self.games = self.__filter_list_of_games(all_games, self.config.preferred_teams)
+        elif self.config.rotation_only_preferred_divisions:
+          self.games = self.__filter_list_of_games(all_games, self.__get_teams_from_divisions(self.config.preferred_divisions))
         else:
           self.games = all_games
 
@@ -219,6 +221,9 @@ class Data:
 
   def __filter_list_of_games(self, games, teams):
     return list(game for game in set(games) if set([game.away_team, game.home_team]).intersection(set(teams)))
+
+  def __get_teams_from_divisions(self, divisions):
+    return list(team.short_name for division in self.standings.divisions for team in division.teams if division.name in divisions)
 
   def __game_index_for(self, team_name):
     team_index = 0

--- a/data/scoreboard_config.py
+++ b/data/scoreboard_config.py
@@ -41,7 +41,8 @@ class ScoreboardConfig:
     # Rotation
     self.rotation_enabled = json["rotation"]["enabled"]
     self.rotation_scroll_until_finished = json["rotation"]["scroll_until_finished"]
-    self.rotation_only_preferred = json["rotation"]["only_preferred"]
+    self.rotation_only_preferred_teams = json["rotation"]["only_preferred_teams"]
+    self.rotation_only_preferred_divisions = json["rotation"]["only_preferred_divisions"]
     self.rotation_rates = json["rotation"]["rates"]
     self.rotation_preferred_team_live_enabled = json["rotation"]["while_preferred_team_live"]["enabled"]
     self.rotation_preferred_team_live_mid_inning = json["rotation"]["while_preferred_team_live"]["during_inning_breaks"]

--- a/data/standings.py
+++ b/data/standings.py
@@ -43,44 +43,45 @@ class Division:
 
 
 class Team:
-    __TEAM_ABBREVIATIONS = {
-        'Arizona Diamondbacks': 'ARI',
-        'Atlanta Braves': 'ATL',
-        'Baltimore Orioles': 'BAL',
-        'Boston Red Sox': 'BOS',
-        'Chicago Cubs': 'CHC',
-        'Chicago White Sox': 'CHW',
-        'Cincinnati Reds': 'CIN',
-        'Cleveland Indians': 'CLE',
-        'Colorado Rockies': 'COL',
-        'Detroit Tigers': 'DET',
-        'Florida Marlins': 'FLA',
-        'Houston Astros': 'HOU',
-        'Kansas City Royals': 'KAN',
-        'Los Angeles Angels': 'LAA',
-        'Los Angeles Dodgers': 'LAD',
-        'Miami Marlins': 'MIA',
-        'Milwaukee Brewers': 'MIL',
-        'Minnesota Twins': 'MIN',
-        'New York Mets': 'NYM',
-        'New York Yankees': 'NYY',
-        'Oakland Athletics': 'OAK',
-        'Philadelphia Phillies': 'PHI',
-        'Pittsburgh Pirates': 'PIT',
-        'San Diego Padres': 'SD',
-        'San Francisco Giants': 'SF',
-        'Seattle Mariners': 'SEA',
-        'St. Louis Cardinals': 'STL',
-        'Tampa Bay Rays': 'TB',
-        'Texas Rangers': 'TEX',
-        'Toronto Blue Jays': 'TOR',
-        'Washington Nationals': 'WAS',
+    __TEAM_NAMES = {
+        'Arizona Diamondbacks': {'abbrev': 'ARI', 'short': 'Diamondbacks'},
+        'Atlanta Braves': {'abbrev': 'ATL', 'short': 'Braves'},
+        'Baltimore Orioles': {'abbrev': 'BAL', 'short': 'Orioles'},
+        'Boston Red Sox': {'abbrev': 'BOS', 'short': 'Red Sox'},
+        'Chicago Cubs': {'abbrev': 'CHC', 'short': 'Cubs'},
+        'Chicago White Sox': {'abbrev': 'CHW', 'short': 'White Sox'},
+        'Cincinnati Reds': {'abbrev': 'CIN', 'short': 'Reds'},
+        'Cleveland Indians': {'abbrev': 'CLE', 'short': 'Indians'},
+        'Colorado Rockies': {'abbrev': 'COL', 'short': 'Rockies'},
+        'Detroit Tigers': {'abbrev': 'DET', 'short': 'Tigers'},
+        'Florida Marlins': {'abbrev': 'FLA', 'short': 'Marlins'},
+        'Houston Astros': {'abbrev': 'HOU', 'short': 'Astros'},
+        'Kansas City Royals': {'abbrev': 'KAN', 'short': 'Royals'},
+        'Los Angeles Angels': {'abbrev': 'LAA', 'short': 'Angels'},
+        'Los Angeles Dodgers': {'abbrev': 'LAD', 'short': 'Dodgers'},
+        'Miami Marlins': {'abbrev': 'MIA', 'short': 'Marlins'},
+        'Milwaukee Brewers': {'abbrev': 'MIL', 'short': 'Brewers'},
+        'Minnesota Twins': {'abbrev': 'MIN', 'short': 'Twins'},
+        'New York Mets': {'abbrev': 'NYM', 'short': 'Mets'},
+        'New York Yankees': {'abbrev': 'NYY', 'short': 'Yankees'},
+        'Oakland Athletics': {'abbrev': 'OAK', 'short': 'Athletics'},
+        'Philadelphia Phillies': {'abbrev': 'PHI', 'short': 'Phillies'},
+        'Pittsburgh Pirates': {'abbrev': 'PIT', 'short': 'Pirates'},
+        'San Diego Padres': {'abbrev': 'SD', 'short': 'Padres'},
+        'San Francisco Giants': {'abbrev': 'SF', 'short': 'Giants'},
+        'Seattle Mariners': {'abbrev': 'SEA', 'short': 'Mariners'},
+        'St. Louis Cardinals': {'abbrev': 'STL', 'short': 'Cardinals'},
+        'Tampa Bay Rays': {'abbrev': 'TB', 'short': 'Rays'},
+        'Texas Rangers': {'abbrev': 'TEX', 'short': 'Rangers'},
+        'Toronto Blue Jays': {'abbrev': 'TOR', 'short': 'Blue Jays'},
+        'Washington Nationals': {'abbrev': 'WAS', 'short': 'Nationals'},
     }
 
     def __init__(self, data, division_id):
         self.__data = data
         self.name = self.__name()
-        self.team_abbrev = self.__TEAM_ABBREVIATIONS[self.name]
+        self.short_name = self.__TEAM_NAMES[self.name]["short"]
+        self.team_abbrev = self.__TEAM_NAMES[self.name]["abbrev"]
         self.w = self.__parse_wins()
         self.l = self.__parse_losses()
         self.gb = self.__data['divisionGamesBack']


### PR DESCRIPTION
This adds support to be able to rotate games through `preferred_divisions` instead of only `preferred_teams` and all games.

This contains a breaking change to the config.json, not sure what the process is on versioning for these. It could probably be modified to be non-breaking if needed.

The dictionary change in `standings.py` is a bit ugly, but I didn't immediately see a way to match the way the game store the team name with the way the standings (and thus the divisions) store the team name.

Closes #125 