### PR TITLE
Truncate team name if Runs or Hits > 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A default `config.json.example` file is included for reference. Copy this file t
 "time_format"                  String  Sets the preferred hour format for displaying time. Accepted values are "12h" or "24h" depending on which you prefer.
 "end_of_day"                   String  A 24-hour time you wish to consider the end of the previous day before starting to display the current day's games. Uses local time from your pi.
 "full_team_names"              Bool    If true and on a 64-wide board, displays the full team name on the scoreboard instead of their abbreviation. This config option is ignored on 32-wide boards. Defaults to true when on a 64-wide board.
+"short_team_names_for_runs_hits" Bool If true and full_team_names is true and Runs Hits Errors is enabled, will use abreviated team names when Runs or Hits > 9
 "scrolling_speed"              Integer Supports an integer between 0 and 4. Sets how fast the scrolling text scrolls.
 "debug"                        Bool    Game and other debug data is written to your console.
 "demo_date"                    String  A date in the format YYYY-MM-DD from which to pull data to demonstrate the scoreboard. A value of `false` will disable demo mode.

--- a/config.json.example
+++ b/config.json.example
@@ -42,6 +42,7 @@
 	"time_format": "12h",
 	"end_of_day": "00:00",
 	"full_team_names": true,
+	"short_team_names_for_runs_hits": true,
 	"scrolling_speed": 2,
 	"debug": false,
 	"demo_date": false

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -62,6 +62,7 @@ class Config:
         self.time_format = json["time_format"]
         self.end_of_day = json["end_of_day"]
         self.full_team_names = json["full_team_names"]
+        self.short_team_names_for_runs_hits = json["short_team_names_for_runs_hits"]
         self.debug = json["debug"]
         self.demo_date = json["demo_date"]
         # Make sure the scrolling speed setting is in range so we don't crash

--- a/data/game.py
+++ b/data/game.py
@@ -66,7 +66,7 @@ class Game:
 
     def home_name(self):
         if (self._data["liveData"]["linescore"]["teams"]["home"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["home"].get("hits", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("hits", 0) > 9 ):
-               return self._data["gameData"]["teams"]["home"]["teamName"][0:8]
+               self._data["gameData"]["teams"]["home"]["abbreviation"]
         else:
             return self._data["gameData"]["teams"]["home"]["teamName"]
     def home_abbreviation(self):
@@ -74,7 +74,7 @@ class Game:
 
     def away_name(self):
         if (self._data["liveData"]["linescore"]["teams"]["home"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["home"].get("hits", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("hits", 0) > 9 ):
-            return self._data["gameData"]["teams"]["away"]["teamName"][0:8]
+            return self._data["gameData"]["teams"]["away"]["abbreviation"]
         else:
             return self._data["gameData"]["teams"]["away"]["teamName"]
 

--- a/data/game.py
+++ b/data/game.py
@@ -65,18 +65,13 @@ class Game:
         return datetime.fromisoformat(time.replace("Z", "+00:00"))
 
     def home_name(self):
-        if (self._data["liveData"]["linescore"]["teams"]["home"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["home"].get("hits", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("hits", 0) > 9 ):
-               self._data["gameData"]["teams"]["home"]["abbreviation"]
-        else:
-            return self._data["gameData"]["teams"]["home"]["teamName"]
+        return self._data["gameData"]["teams"]["home"]["teamName"]
+    
     def home_abbreviation(self):
         return self._data["gameData"]["teams"]["home"]["abbreviation"]
 
     def away_name(self):
-        if (self._data["liveData"]["linescore"]["teams"]["home"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["home"].get("hits", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("hits", 0) > 9 ):
-            return self._data["gameData"]["teams"]["away"]["abbreviation"]
-        else:
-            return self._data["gameData"]["teams"]["away"]["teamName"]
+        return self._data["gameData"]["teams"]["away"]["teamName"]
 
     def away_abbreviation(self):
         return self._data["gameData"]["teams"]["away"]["abbreviation"]

--- a/data/game.py
+++ b/data/game.py
@@ -65,13 +65,18 @@ class Game:
         return datetime.fromisoformat(time.replace("Z", "+00:00"))
 
     def home_name(self):
-        return self._data["gameData"]["teams"]["home"]["teamName"]
-
+        if (self._data["liveData"]["linescore"]["teams"]["home"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["home"].get("hits", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("hits", 0) > 9 ):
+               return self._data["gameData"]["teams"]["home"]["teamName"][0:8]
+        else:
+            return self._data["gameData"]["teams"]["home"]["teamName"]
     def home_abbreviation(self):
         return self._data["gameData"]["teams"]["home"]["abbreviation"]
 
     def away_name(self):
-        return self._data["gameData"]["teams"]["away"]["teamName"]
+        if (self._data["liveData"]["linescore"]["teams"]["home"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("runs", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["home"].get("hits", 0) > 9) or (self._data["liveData"]["linescore"]["teams"]["away"].get("hits", 0) > 9 ):
+            return self._data["gameData"]["teams"]["away"]["teamName"][0:8]
+        else:
+            return self._data["gameData"]["teams"]["away"]["teamName"]
 
     def away_abbreviation(self):
         return self._data["gameData"]["teams"]["away"]["abbreviation"]

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -82,7 +82,7 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
     coords = layout.coords("teams.name.{}".format(homeaway))
     font = layout.font("teams.name.{}".format(homeaway))
     team_text = "{:3s}".format(team.abbrev.upper())
-    if full_team_names and canvas.width > 32 and not (short_team_names_for_runs_hits and (team.runs > 9 or team.hits > 9 or vs_team.runs > 9 or vs_team.hits > 9)):
+    if use_full_team_names:
         team_text = "{:13s}".format(team.name)
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
 

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -53,8 +53,8 @@ def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_t
                 y_offset = accent_coords[team]["y"]
                 canvas.SetPixel(x + x_offset, y + y_offset, color["r"], color["g"], color["b"])
 
-    __render_team_text(canvas, layout, away_colors, away_team, "away", full_team_names, default_colors, short_team_names_for_runs_hits)
-    __render_team_text(canvas, layout, home_colors, home_team, "home", full_team_names, default_colors, short_team_names_for_runs_hits)
+    __render_team_text(canvas, layout, away_colors, away_team, "away", full_team_names, default_colors, short_team_names_for_runs_hits, home_team)
+    __render_team_text(canvas, layout, home_colors, home_team, "home", full_team_names, default_colors, short_team_names_for_runs_hits, away_team)
 
     # Number of characters in each score.
     score_spacing = {
@@ -74,13 +74,13 @@ def __team_colors(team_colors, team_abbrev):
     return team_colors
 
 
-def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, default_colors, short_team_names_for_runs_hits):
+def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, default_colors, short_team_names_for_runs_hits, vs_team):
     text_color = colors.get("text", default_colors["text"])
     text_color_graphic = graphics.Color(text_color["r"], text_color["g"], text_color["b"])
     coords = layout.coords("teams.name.{}".format(homeaway))
     font = layout.font("teams.name.{}".format(homeaway))
     team_text = "{:3s}".format(team.abbrev.upper())
-    if full_team_names and canvas.width > 32 and not (short_team_names_for_runs_hits and (team.runs > 9 or team.hits > 9)):
+    if full_team_names and canvas.width > 32 and not (short_team_names_for_runs_hits and (team.runs > 9 or team.hits > 9 or vs_team.runs > 9 or vs_team.hits > 9)):
         team_text = "{:13s}".format(team.name)
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
 

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -86,6 +86,15 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
         team_text = "{:13s}".format(team.name)
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
 
+def __can_use_full_team_names(canvas, enabled, abbreviate_on_overflow, teams):
+    if enabled and canvas.width > 32:
+        if abbreviate_on_overflow:
+            for team in teams:
+                if team.runs > 9 or team.hits > 9:
+                    return False
+    else:
+        return True
+    return False
 
 def __render_score_component(canvas, layout, colors, homeaway, default_colors, coords, component_val, width_chars):
     # The coords passed in are the rightmost pixel.

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -53,8 +53,10 @@ def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_t
                 y_offset = accent_coords[team]["y"]
                 canvas.SetPixel(x + x_offset, y + y_offset, color["r"], color["g"], color["b"])
 
-    __render_team_text(canvas, layout, away_colors, away_team, "away", full_team_names, default_colors, short_team_names_for_runs_hits, home_team)
-    __render_team_text(canvas, layout, home_colors, home_team, "home", full_team_names, default_colors, short_team_names_for_runs_hits, away_team)
+    use_full_team_names = can_use_full_team_names(canvas, full_team_names, short_team_names_for_runs_hits, [home_team, away_team])
+
+    __render_team_text(canvas, layout, away_colors, away_team, "away", use_full_team_names, default_colors)
+    __render_team_text(canvas, layout, home_colors, home_team, "home", use_full_team_names, default_colors)
 
     # Number of characters in each score.
     score_spacing = {

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -4,7 +4,7 @@ except ImportError:
     from RGBMatrixEmulator import graphics
 
 
-def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_team_names):
+def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_team_names, short_team_names_for_runs_hits,):
     default_colors = team_colors.color("default")
 
     away_colors = __team_colors(team_colors, away_team.abbrev)
@@ -53,8 +53,8 @@ def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_t
                 y_offset = accent_coords[team]["y"]
                 canvas.SetPixel(x + x_offset, y + y_offset, color["r"], color["g"], color["b"])
 
-    __render_team_text(canvas, layout, away_colors, away_team, "away", full_team_names, default_colors)
-    __render_team_text(canvas, layout, home_colors, home_team, "home", full_team_names, default_colors)
+    __render_team_text(canvas, layout, away_colors, away_team, "away", full_team_names, default_colors, short_team_names_for_runs_hits)
+    __render_team_text(canvas, layout, home_colors, home_team, "home", full_team_names, default_colors, short_team_names_for_runs_hits)
 
     # Number of characters in each score.
     score_spacing = {
@@ -74,14 +74,16 @@ def __team_colors(team_colors, team_abbrev):
     return team_colors
 
 
-def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, default_colors):
+def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, default_colors, short_team_names_for_runs_hits):
     text_color = colors.get("text", default_colors["text"])
     text_color_graphic = graphics.Color(text_color["r"], text_color["g"], text_color["b"])
     coords = layout.coords("teams.name.{}".format(homeaway))
     font = layout.font("teams.name.{}".format(homeaway))
     team_text = "{:3s}".format(team.abbrev.upper())
-    if full_team_names and canvas.width > 32:
+    if full_team_names and canvas.width > 32 and short_team_names_for_runs_hits == False:
         team_text = "{:13s}".format(team.name)
+    if full_team_names and canvas.width > 32 and short_team_names_for_runs_hits and (team.runs > 9 or team.hits > 9 ) :
+        team_text = "{:3s}".format(team.abbrev.upper())
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
 
 

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -80,10 +80,8 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
     coords = layout.coords("teams.name.{}".format(homeaway))
     font = layout.font("teams.name.{}".format(homeaway))
     team_text = "{:3s}".format(team.abbrev.upper())
-    if full_team_names and canvas.width > 32 and short_team_names_for_runs_hits == False:
+    if full_team_names and canvas.width > 32 and not (short_team_names_for_runs_hits and (team.runs > 9 or team.hits > 9)):
         team_text = "{:13s}".format(team.name)
-    if full_team_names and canvas.width > 32 and short_team_names_for_runs_hits and (team.runs > 9 or team.hits > 9 ) :
-        team_text = "{:3s}".format(team.abbrev.upper())
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
 
 

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     from RGBMatrixEmulator import graphics
 
-
 def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_team_names, short_team_names_for_runs_hits,):
     default_colors = team_colors.color("default")
 
@@ -55,8 +54,8 @@ def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_t
 
     use_full_team_names = can_use_full_team_names(canvas, full_team_names, short_team_names_for_runs_hits, [home_team, away_team])
 
-    __render_team_text(canvas, layout, away_colors, away_team, "away", use_full_team_names, default_colors)
-    __render_team_text(canvas, layout, home_colors, home_team, "home", use_full_team_names, default_colors)
+    __render_team_text(canvas, layout, away_colors, away_team, "away", use_full_team_names, default_colors, use_full_team_names)
+    __render_team_text(canvas, layout, home_colors, home_team, "home", use_full_team_names, default_colors, use_full_team_names)
 
     # Number of characters in each score.
     score_spacing = {
@@ -67,6 +66,15 @@ def render_team_banner(canvas, layout, team_colors, home_team, away_team, full_t
     __render_team_score(canvas, layout, away_colors, away_team, "away", default_colors, score_spacing)
     __render_team_score(canvas, layout, home_colors, home_team, "home", default_colors, score_spacing)
 
+def can_use_full_team_names(canvas, enabled, abbreviate_on_overflow, teams):
+    if enabled and canvas.width > 32:
+        if abbreviate_on_overflow:
+            for team in teams:
+                if team.runs > 9 or team.hits > 9:
+                    return False
+    else:
+        return True
+    return False
 
 def __team_colors(team_colors, team_abbrev):
     try:
@@ -76,7 +84,7 @@ def __team_colors(team_colors, team_abbrev):
     return team_colors
 
 
-def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, default_colors, short_team_names_for_runs_hits, vs_team):
+def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, default_colors, use_full_team_names):
     text_color = colors.get("text", default_colors["text"])
     text_color_graphic = graphics.Color(text_color["r"], text_color["g"], text_color["b"])
     coords = layout.coords("teams.name.{}".format(homeaway))
@@ -85,16 +93,6 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
     if use_full_team_names:
         team_text = "{:13s}".format(team.name)
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
-
-def __can_use_full_team_names(canvas, enabled, abbreviate_on_overflow, teams):
-    if enabled and canvas.width > 32:
-        if abbreviate_on_overflow:
-            for team in teams:
-                if team.runs > 9 or team.hits > 9:
-                    return False
-    else:
-        return True
-    return False
 
 def __render_score_component(canvas, layout, colors, homeaway, default_colors, coords, component_val, width_chars):
     # The coords passed in are the rightmost pixel.

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -157,6 +157,7 @@ class MainRenderer:
             scoreboard.home_team,
             scoreboard.away_team,
             self.data.config.full_team_names,
+            self.data.config.short_team_names_for_runs_hits,
         )
 
         if status.is_pregame(game.status()):  # Draw the pregame information


### PR DESCRIPTION
If Runs or Hits > 9 (double digits) then truncate the long team name for the display so they don't overflow each other.  There is probably a better way of fixing this.