### PR TITLE
Add pregame weather

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -43,6 +43,7 @@
 	"end_of_day": "00:00",
 	"full_team_names": true,
 	"short_team_names_for_runs_hits": true,
+	"pregame_weather": true,
 	"scrolling_speed": 2,
 	"debug": false,
 	"demo_date": false

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -63,6 +63,7 @@ class Config:
         self.end_of_day = json["end_of_day"]
         self.full_team_names = json["full_team_names"]
         self.short_team_names_for_runs_hits = json["short_team_names_for_runs_hits"]
+        self.pregame_weather = json["pregame_weather"]
         self.debug = json["debug"]
         self.demo_date = json["demo_date"]
         # Make sure the scrolling speed setting is in range so we don't crash

--- a/data/game.py
+++ b/data/game.py
@@ -11,7 +11,7 @@ API_FIELDS = (
     + "reason,probablePitchers,teams,home,away,abbreviation,teamName,players,id,boxscoreName,fullName,liveData,plays,"
     + "currentPlay,result,eventType,description,decisions,winner,loser,save,id,linescore,outs,balls,strikes,note,"
     + "inningState,currentInning,currentInningOrdinal,offense,batter,inHole,onDeck,first,second,third,defense,pitcher,"
-    + "boxscore,teams,runs,players,seasonStats,pitching,wins,losses,saves,era,hits,errors"
+    + "boxscore,teams,runs,players,seasonStats,pitching,wins,losses,saves,era,hits,errors,weather,condition,temp,wind"
 )
 
 SCHEDULE_API_FIELDS = "dates,date,games,status,detailedState,abstractGameState,reason"
@@ -69,7 +69,15 @@ class Game:
     
     def home_abbreviation(self):
         return self._data["gameData"]["teams"]["home"]["abbreviation"]
-
+    
+    def pregame_weather(self):
+        try:
+            wx = self._data["gameData"]["weather"]["condition"] + " and " + self._data["gameData"]["weather"]["temp"] + u"\N{DEGREE SIGN}" + " wind " + self._data["gameData"]["weather"]["wind"]
+        except KeyError:
+            return None
+        else:
+            return wx 
+    
     def away_name(self):
         return self._data["gameData"]["teams"]["away"]["teamName"]
 

--- a/data/scoreboard/pregame.py
+++ b/data/scoreboard/pregame.py
@@ -9,6 +9,7 @@ class Pregame:
     def __init__(self, game: Game, time_format):
         self.home_team = game.home_abbreviation()
         self.away_team = game.away_abbreviation()
+        self.pregame_weather = game.pregame_weather()
         self.time_format = time_format
 
         try:

--- a/renderers/games/pregame.py
+++ b/renderers/games/pregame.py
@@ -10,8 +10,8 @@ from renderers import scrollingtext
 from utils import center_text_position
 
 
-def render_pregame(canvas, layout: Layout, colors: Color, pregame: Pregame, probable_starter_pos):
-    text_len = _render_probable_starters(canvas, layout, colors, pregame, probable_starter_pos)
+def render_pregame(canvas, layout: Layout, colors: Color, pregame: Pregame, probable_starter_pos, pregame_weather):
+    text_len = _render_probable_starters(canvas, layout, colors, pregame, probable_starter_pos, pregame_weather)
 
     if layout.state_is_warmup():
         _render_warmup(canvas, layout, colors, pregame)
@@ -39,12 +39,15 @@ def _render_warmup(canvas, layout, colors, pregame):
     graphics.DrawText(canvas, font["font"], warmup_x, coords["y"], color, warmup_text)
 
 
-def _render_probable_starters(canvas, layout, colors, pregame, probable_starter_pos):
+def _render_probable_starters(canvas, layout, colors, pregame, probable_starter_pos, pregame_weather):
     coords = layout.coords("pregame.scrolling_text")
     font = layout.font("pregame.scrolling_text")
     color = colors.graphics_color("pregame.scrolling_text")
     bgcolor = colors.graphics_color("default.background")
-    pitchers_text = pregame.away_starter + " vs " + pregame.home_starter
+    if pregame_weather and pregame.pregame_weather:
+        pitchers_text = pregame.away_starter + " vs " + pregame.home_starter + " Weather: " + pregame.pregame_weather
+    else :
+        pitchers_text = pregame.away_starter + " vs " + pregame.home_starter
     return scrollingtext.render_text(
         canvas, coords["x"], coords["y"], coords["width"], font, color, bgcolor, pitchers_text, probable_starter_pos
     )

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -163,7 +163,7 @@ class MainRenderer:
         if status.is_pregame(game.status()):  # Draw the pregame information
             self.__max_scroll_x(layout.coords("pregame.scrolling_text"))
             pregame = Pregame(game, self.data.config.time_format)
-            pos = pregamerender.render_pregame(self.canvas, layout, colors, pregame, self.scrolling_text_pos)
+            pos = pregamerender.render_pregame(self.canvas, layout, colors, pregame, self.scrolling_text_pos, self.data.config.pregame_weather)
             self.__update_scrolling_text_pos(pos, self.canvas.width)
 
         elif status.is_complete(game.status()):  # Draw the game summary


### PR DESCRIPTION
Added pregame weather.  In config.json must add `"pregame_weather": true,` note that pregame weather appears to be entered manually when the booth crew shows up.  For tonight's yankees game the api populated around 3pm today for a 7:05 start.