### PR TITLE
Ensure preferred game index is bounded by game list length

### DIFF
--- a/data/schedule.py
+++ b/data/schedule.py
@@ -126,15 +126,18 @@ class Schedule:
         return self.__current_game()
 
     def _game_index_for_preferred_team(self):
+        target_index = self.current_idx
+
         if self.config.preferred_teams:
             team_name = data.teams.TEAM_FULL[self.config.preferred_teams[0]]
-            team_index = self.current_idx
             team_idxs = [i for i, game in enumerate(self._games) if team_name in [game["away_name"], game["home_name"]]]
             if len(team_idxs) > 0:
-                team_index = next((i for i in team_idxs if status.is_live(self._games[i]["status"])), team_idxs[0],)
-            return team_index
-        else:
-            return self.current_idx
+                target_index = next((i for i in team_idxs if status.is_live(self._games[i]["status"])), team_idxs[0],)
+
+        if target_index >= len(self._games):
+            target_index = 0
+
+        return target_index
 
     def __next_game_index(self):
         counter = self.current_idx + 1


### PR DESCRIPTION
Closes #410 & #362 which was previously closed earlier this season when we rolled to v5

We guard against `IndexError` in other places by rolling over to 0 on overflow (namely the call to `__next_game_index`). For some reason this function just never had the same handling for that issue in the preferred games index

My hunch is that the call to refresh the games list returns a list that's smaller than current index. Normally this isn't a problem, but when current index >= new list size AND when preferred team isn't live, you'd go out of bounds. This will be hard to test unfortunately as it is very dependent on data in the MLB API. To me, this type of guard feels like a good idea even if it doesn't fully address this issue.

Stack traces for the two issues are almost identical. Latest version (5.1.4) changes the `next_game` call slightly but would not affect this issue

---

Copying the stack trace here for visibility:

```
ERROR (12:42:26): Untrapped error in main!
Traceback (most recent call last):
  File "/home/pi/mlb-led-scoreboard/main.py", line 144, in <module>
    main(matrix, config)
  File "/home/pi/mlb-led-scoreboard/main.py", line 78, in main
    __refresh_games(render, data)
  File "/home/pi/mlb-led-scoreboard/main.py", line 115, in __refresh_games
    data.advance_to_next_game()
  File "/home/pi/mlb-led-scoreboard/data/__init__.py", line 75, in advance_to_next_game
    game = self.schedule.next_game()
  File "/home/pi/mlb-led-scoreboard/data/schedule.py", line 106, in next_game
    preferred_game = Game.from_ID(self._games[game_index]["game_id"], self.date)
IndexError: list index out of range
```