### PR TITLE
Add series status to pre/postgame scroll during playoffs

### DIFF
--- a/data/game.py
+++ b/data/game.py
@@ -1,5 +1,6 @@
 import time
 from datetime import datetime
+from typing import Optional
 
 import statsapi
 
@@ -22,18 +23,24 @@ GAME_UPDATE_RATE = 10
 
 class Game:
     @staticmethod
-    def from_ID(game_id, date, broadcasts=None):
-        game = Game(game_id, date, broadcasts or [])
+    def from_scheduled(game_data) -> Optional["Game"]:
+        game = Game(
+            game_data["game_id"],
+            game_data["game_date"],
+            game_data["national_broadcasts"] or [],
+            game_data["series_status"] or "",
+        )
         if game.update(True) == UpdateStatus.SUCCESS:
             return game
         return None
 
-    def __init__(self, game_id, date, broadcasts):
+    def __init__(self, game_id, date, broadcasts, series_status):
         self.game_id = game_id
-        self.date = date.strftime("%Y-%m-%d")
+        self.date = date
         self.starttime = time.time()
         self._data = {}
         self._broadcasts = broadcasts
+        self._series_status = series_status
         self._status = {}
 
     def update(self, force=False) -> UpdateStatus:
@@ -263,6 +270,9 @@ class Game:
 
     def broadcasts(self):
         return self._broadcasts
+
+    def series_status(self):
+        return self._series_status
 
     def current_play_result(self):
         result = self._data["liveData"]["plays"].get("currentPlay", {}).get("result", {}).get("eventType", "")

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -104,7 +104,7 @@ class Schedule:
         ):
             game_index = self._game_index_for_preferred_team()
             scheduled_game = self._games[game_index]
-            preferred_game = Game.from_ID(scheduled_game["game_id"], self.date, scheduled_game["national_broadcasts"])
+            preferred_game = Game.from_scheduled(scheduled_game)
             if preferred_game is not None:
                 debug.log(
                     "Preferred Team's Game Status: %s, %s %d",
@@ -146,7 +146,7 @@ class Schedule:
     def __current_game(self):
         if self._games:
             scheduled_game = self._games[self.current_idx]
-            return Game.from_ID(scheduled_game["game_id"], self.date, scheduled_game["national_broadcasts"])
+            return Game.from_scheduled(scheduled_game)
         return None
 
     @staticmethod

--- a/data/scoreboard/postgame.py
+++ b/data/scoreboard/postgame.py
@@ -37,6 +37,9 @@ class Postgame:
             self.losing_pitcher_wins = 0
             self.losing_pitcher_losses = 0
 
+        self.series_status = game.series_status()
+
+
     def __str__(self):
         return "<{} {}> W: {} {}-{}; L: {} {}-{}; S: {} ({})".format(
             self.__class__.__name__,

--- a/data/scoreboard/pregame.py
+++ b/data/scoreboard/pregame.py
@@ -40,6 +40,7 @@ class Pregame:
             self.home_starter = PITCHER_TBD
 
         self.national_broadcasts = game.broadcasts()
+        self.series_status = game.series_status()
 
     def __convert_time(self, game_time_utc):
         """Converts MLB's pregame times (UTC) into the local time zone"""

--- a/renderers/games/postgame.py
+++ b/renderers/games/postgame.py
@@ -10,12 +10,14 @@ from utils import center_text_position
 NORMAL_GAME_LENGTH = 9
 
 
-def render_postgame(canvas, layout: Layout, colors: Color, postgame: Postgame, scoreboard: Scoreboard, text_pos):
+def render_postgame(
+    canvas, layout: Layout, colors: Color, postgame: Postgame, scoreboard: Scoreboard, text_pos, is_playoffs
+):
     _render_final_inning(canvas, layout, colors, scoreboard)
-    return _render_decision_scroll(canvas, layout, colors, postgame, text_pos)
+    return _render_decision_scroll(canvas, layout, colors, postgame, text_pos, is_playoffs)
 
 
-def _render_decision_scroll(canvas, layout, colors, postgame, text_pos):
+def _render_decision_scroll(canvas, layout, colors, postgame, text_pos, is_playoffs):
     coords = layout.coords("final.scrolling_text")
     font = layout.font("final.scrolling_text")
     color = colors.graphics_color("final.scrolling_text")
@@ -30,6 +32,10 @@ def _render_decision_scroll(canvas, layout, colors, postgame, text_pos):
     )
     if postgame.save_pitcher:
         scroll_text += " SV: {} ({})".format(postgame.save_pitcher, postgame.save_pitcher_saves)
+
+    if is_playoffs:
+        scroll_text += "   " + postgame.series_status
+
     return scrollingtext.render_text(
         canvas, coords["x"], coords["y"], coords["width"], font, color, bgcolor, scroll_text, text_pos
     )

--- a/renderers/games/pregame.py
+++ b/renderers/games/pregame.py
@@ -6,8 +6,10 @@ from renderers import scrollingtext
 from utils import center_text_position
 
 
-def render_pregame(canvas, layout: Layout, colors: Color, pregame: Pregame, probable_starter_pos, pregame_weather):
-    text_len = _render_pregame_info(canvas, layout, colors, pregame, probable_starter_pos, pregame_weather)
+def render_pregame(
+    canvas, layout: Layout, colors: Color, pregame: Pregame, probable_starter_pos, pregame_weather, is_playoffs
+):
+    text_len = _render_pregame_info(canvas, layout, colors, pregame, probable_starter_pos, pregame_weather, is_playoffs)
 
     if layout.state_is_warmup():
         _render_warmup(canvas, layout, colors, pregame)
@@ -35,7 +37,7 @@ def _render_warmup(canvas, layout, colors, pregame):
     graphics.DrawText(canvas, font["font"], warmup_x, coords["y"], color, warmup_text)
 
 
-def _render_pregame_info(canvas, layout, colors, pregame, probable_starter_pos, pregame_weather):
+def _render_pregame_info(canvas, layout, colors, pregame: Pregame, probable_starter_pos, pregame_weather, is_playoffs):
     coords = layout.coords("pregame.scrolling_text")
     font = layout.font("pregame.scrolling_text")
     color = colors.graphics_color("pregame.scrolling_text")
@@ -45,6 +47,9 @@ def _render_pregame_info(canvas, layout, colors, pregame, probable_starter_pos, 
         pitchers_text += " TV: " + ", ".join(pregame.national_broadcasts)
     if pregame_weather and pregame.pregame_weather:
         pitchers_text += " Weather: " + pregame.pregame_weather
+
+    if is_playoffs:
+        pitchers_text += "   " + pregame.series_status
 
     return scrollingtext.render_text(
         canvas, coords["x"], coords["y"], coords["width"], font, color, bgcolor, pitchers_text, probable_starter_pos

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -18,6 +18,7 @@ class MainRenderer:
     def __init__(self, matrix, data):
         self.matrix = matrix
         self.data: Data = data
+        self.is_playoffs = self.data.schedule.date > self.data.headlines.important_dates.playoffs_start_date
         self.canvas = matrix.CreateFrameCanvas()
         self.scrolling_text_pos = self.canvas.width
         self.game_changed_time = time.time()
@@ -164,7 +165,13 @@ class MainRenderer:
             self.__max_scroll_x(layout.coords("pregame.scrolling_text"))
             pregame = Pregame(game, self.data.config.time_format)
             pos = pregamerender.render_pregame(
-                self.canvas, layout, colors, pregame, self.scrolling_text_pos, self.data.config.pregame_weather
+                self.canvas,
+                layout,
+                colors,
+                pregame,
+                self.scrolling_text_pos,
+                self.data.config.pregame_weather,
+                self.is_playoffs,
             )
             self.__update_scrolling_text_pos(pos, self.canvas.width)
 
@@ -172,7 +179,7 @@ class MainRenderer:
             self.__max_scroll_x(layout.coords("final.scrolling_text"))
             final = Postgame(game)
             pos = postgamerender.render_postgame(
-                self.canvas, layout, colors, final, scoreboard, self.scrolling_text_pos
+                self.canvas, layout, colors, final, scoreboard, self.scrolling_text_pos, self.is_playoffs
             )
             self.__update_scrolling_text_pos(pos, self.canvas.width)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 feedparser==6.0.10
-MLB_StatsAPI==1.5.1
+MLB_StatsAPI>=1.6.1
 Pillow==9.1.1
 pyowm==3.3.0
 RGBMatrixEmulator>=0.8.1

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
 SCRIPT_NAME = "MLB LED Scoreboard"
-SCRIPT_VERSION = "5.1.5"
+SCRIPT_VERSION = "6.0.0"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on a PR I did for MLB-StatsAPI last year: https://github.com/toddrob99/MLB-StatsAPI/pull/95

Adds text like "HOU leads 2-0", or "Series tied 1-1" to the end of the scroll (after the weather for pregame, after the save pitcher for postgame).

Requires MLB-StatsAPI version 1.6 or higher