### PR TITLE
Fix pitch count for home team

### DIFF
--- a/data/game.py
+++ b/data/game.py
@@ -260,7 +260,7 @@ class Game:
             try:
                 return self._data["liveData"]["boxscore"]["teams"]["away"]["players"][ID]["stats"]["pitching"]["numberOfPitches"]
             except:
-                return self._data["liveData"]["boxscore"]["teams"]["away"]["players"][ID]["stats"]["pitching"]["numberOfPitches"]
+                return self._data["liveData"]["boxscore"]["teams"]["home"]["players"][ID]["stats"]["pitching"]["numberOfPitches"]
         except:
             return 0
 


### PR DESCRIPTION
Dumb copy/paste error made it so the home team pitch count would always be 0