### PR TITLE
Game data missing broadcast or series status throws an exception

### DIFF
--- a/data/game.py
+++ b/data/game.py
@@ -27,8 +27,8 @@ class Game:
         game = Game(
             game_data["game_id"],
             game_data["game_date"],
-            game_data["national_broadcasts"] or [],
-            game_data["series_status"] or "",
+            game_data.get("national_broadcasts", []),
+            game_data.get("series_status", ""),
         )
         if game.update(True) == UpdateStatus.SUCCESS:
             return game


### PR DESCRIPTION
`Game.from_scheduled` does not handle fetching missing keys from dicts correctly.

```
C:\Users\tyler\development\mlb-led-scoreboard>python main.py
ERROR (12:09:47): Untrapped error in main!
Traceback (most recent call last):
  File "main.py", line 138, in <module>
    main(matrix, config)
  File "main.py", line 59, in main
    data = Data(config)
  File "C:\Users\tyler\development\mlb-led-scoreboard\data\__init__.py", line 25, in __init__
    self.current_game: Game = self.schedule.get_preferred_game()
  File "C:\Users\tyler\development\mlb-led-scoreboard\data\schedule.py", line 93, in get_preferred_game
    return self.__current_game()
  File "C:\Users\tyler\development\mlb-led-scoreboard\data\schedule.py", line 149, in __current_game
    return Game.from_scheduled(scheduled_game)
  File "C:\Users\tyler\development\mlb-led-scoreboard\data\game.py", line 31, in from_scheduled
    game_data["series_status"] or "",
KeyError: 'series_status'
```