### PR TITLE
Allow news ticker when no games are live

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ A default `config.json.example` file is included for reference. Copy this file t
   "always_display"               Bool    Display the news ticker screen at all times. Supercedes the standings setting.
   "team_offday"                  Bool    Display the news ticker when your prefered team is on an offday.
   "preferred_teams"              Bool    Include headlines from your list of preferred teams. Will only use the first 3 teams listed in your preferred teams.
+  "display_no_games_live"        Bool    Display news and weather when none of your games are currently live.
   "traderumors"                  Bool    Include headlines from mlbtraderumors.com for your list of preferred teams. Will only use the first 3 teams listed in your preferred teams.
   "mlb_news"                     Bool    Include MLB's frontpage news.
   "countdowns"                   Bool    Include various countdowns in the ticker.
@@ -253,7 +254,7 @@ A default `config.json.example` file is included for reference. Copy this file t
 * The "preferred_game_update_delay_in_10s_of_seconds" will delay the update of your LED board to allow you to synchronize with the boroadcast feed.
 * You can only delay the board in 10 second increments, so a value of 3 coresponds to 30 seconds, 5 to 50 seconds etc.
 * There appears to be a lot of variability in broadcast delays across networks/teams/CDN's.
-* Please note, that if restarting the service with a delay, it will take the value of cycles set for the board to be in sync.  If you set the value to 3, it will take 30-40 seconds for the buffer to fill and the board to delay. 
+* Please note, that if restarting the service with a delay, it will take the value of cycles set for the board to be in sync.  If you set the value to 3, it will take 30-40 seconds for the buffer to fill and the board to delay.
 
 ### Additional Features
 * Runs/Hits/Errors - Runs are always shown on the games screen, but you can enable or adjust spacing of a "runs, hits, errors" display.  Take a look at the [coordinates readme file](/coordinates/README.md) for details.

--- a/config.json.example
+++ b/config.json.example
@@ -7,6 +7,7 @@
 		"team_offday": true,
 		"always_display": false,
 		"preferred_teams": true,
+		"display_no_games_live": false,
 		"traderumors": true,
 		"mlb_news": true,
 		"countdowns": true,

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,5 +1,5 @@
 import time
-
+from data.screens import ScreenType
 
 import debug
 from data import status
@@ -107,32 +107,29 @@ class Data:
         elif status == UpdateStatus.FAIL:
             self.network_issues = True
 
-    def get_screen_type(self):
+    def get_screen_type(self) -> ScreenType:
         # Always the news
         if self.config.news_ticker_always_display:
-            return "news"
+            return ScreenType.ALWAYS_NEWS
         # Always the standings
-        elif self.config.standings_always_display:
-            return "standings"
-
+        if self.config.standings_always_display:
+            return ScreenType.ALWAYS_STANDINGS
         # Full MLB Offday
-        elif self.schedule.is_offday():
-            if self.config.standings_mlb_offday:
-                return "standings"
-            else:
-                return "news"
+        if self.schedule.is_offday():
+            return ScreenType.LEAGUE_OFFDAY
+
         # Preferred Team Offday
-        elif self.schedule.is_offday_for_preferred_team():
-            if self.config.news_ticker_team_offday:
-                return "news"
-            elif self.config.standings_team_offday:
-                return "standings"
+        if self.schedule.is_offday_for_preferred_team() and (
+            self.config.news_ticker_team_offday or self.config.standings_team_offday
+        ):
+            return ScreenType.PREFERRED_TEAM_OFFDAY
+
         # Playball!
-        else:
-            return "games"
+        return ScreenType.GAMEDAY
 
     def __update_layout_state(self):
         import data.config.layout as layout
+
         self.config.layout.set_state()
         if self.current_game.status() == status.WARMUP:
             self.config.layout.set_state(layout.LAYOUT_STATE_WARMUP)

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -34,6 +34,7 @@ class Config:
         self.news_ticker_countdowns = json["news_ticker"]["countdowns"]
         self.news_ticker_date = json["news_ticker"]["date"]
         self.news_ticker_date_format = json["news_ticker"]["date_format"]
+        self.news_no_games = json["news_ticker"]["display_no_games_live"]
 
         # Display Standings
         self.standings_team_offday = json["standings"]["team_offday"]

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -48,14 +48,16 @@ class Schedule:
                 debug.exception("Networking error while refreshing schedule")
                 return UpdateStatus.FAIL
             else:
-                self._games = self.__all_games
+                games = self.__all_games
 
                 if self.config.rotation_only_preferred:
-                    self._games = Schedule.__filter_list_of_games(self.__all_games, self.config.preferred_teams)
+                    games = Schedule.__filter_list_of_games(self.__all_games, self.config.preferred_teams)
                 if self.config.rotation_only_live:
-                    games = [g for g in self._games if status.is_live(g["status"]) or status.is_fresh(g["status"])]
-                    if games:
-                        self._games = games
+                    live_games = [g for g in self._games if status.is_live(g["status"]) or status.is_fresh(g["status"])]
+                    if live_games:
+                        games = live_games
+
+                self._games = games
 
                 return UpdateStatus.SUCCESS
 

--- a/data/screens.py
+++ b/data/screens.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class ScreenType(Enum):
+    """Kinds of screen we render"""
+
+    ALWAYS_NEWS = "news"
+    ALWAYS_STANDINGS = "standings"
+    LEAGUE_OFFDAY = "league_offday"  # complete offday, implies at least news, possibly also standings
+    PREFERRED_TEAM_OFFDAY = (
+        "preferred_team_offday"  # offday only for preferred team AND news/standings are enabled for team offdays
+    )
+    GAMEDAY = "gameday"  # games are being played today. May also show standings and news if games aren't live

--- a/data/standings.py
+++ b/data/standings.py
@@ -62,12 +62,15 @@ class Standings:
                         season_params["date"] = self.date.strftime("%m/%d/%Y")
 
                     divisons_data = statsapi.get("standings", season_params)
-                    self.standings = [Division(division_data) for division_data in divisons_data["records"]]
+                    standings = [Division(division_data) for division_data in divisons_data["records"]]
 
                     if self.wild_cards:
                         season_params["standingsTypes"] = "wildCard"
                         wc_data = statsapi.get("standings", season_params)
-                        self.standings += [Division(data, wc=True) for data in wc_data["records"]]
+                        standings += [Division(data, wc=True) for data in wc_data["records"]]
+
+                    self.standings = standings
+
                 else:
                     postseason_data = statsapi.get(
                         "schedule_postseason_series",

--- a/main.py
+++ b/main.py
@@ -108,14 +108,21 @@ def __refresh_games(render_thread, data):  # type: (threading.Thread, Data) -> N
     while render_thread.is_alive():
         time.sleep(0.5)
         data.refresh_schedule()
-        if data.config.standings_no_games:
-            if not data.schedule.games_live():
+        if not data.schedule.games_live():
+            cont = False
+            if data.config.standings_no_games:
                 data.refresh_standings()
+                cont = True
+            if data.config.news_no_games:
+                data.refresh_news_ticker()
+                cont = True
+            if cont:
                 continue
-            # make sure a game is poulated
-            elif not promise_game:
-                promise_game = True
-                data.advance_to_next_game()
+
+        # make sure a game is poulated
+        elif not promise_game:
+            promise_game = True
+            data.advance_to_next_game()
 
         rotate = data.should_rotate_to_next_game()
         if data.schedule.games_live() and not rotate:

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ def main(matrix, config_base):
     elif screen == "standings":
         __refresh_standings(render, data)
     else:
-        __refresh_games(render, data)
+        __refresh_gameday(render, data)
 
 
 def __refresh_offday(render_thread, data):  # type: (threading.Thread, Data) -> None
@@ -99,7 +99,7 @@ def __refresh_standings(render_thread, data):  # type: (threading.Thread, Data) 
         __refresh_offday(render_thread, data)
 
 
-def __refresh_games(render_thread, data):  # type: (threading.Thread, Data) -> None
+def __refresh_gameday(render_thread, data):  # type: (threading.Thread, Data) -> None
     debug.log("Main has selected the game and schedule information to refresh")
 
     starttime = time.time()
@@ -120,7 +120,7 @@ def __refresh_games(render_thread, data):  # type: (threading.Thread, Data) -> N
             if cont:
                 continue
 
-        # make sure a game is poulated
+        # make sure a game is populated
         elif not promise_game:
             promise_game = True
             data.advance_to_next_game()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import sys
 
+from data.screens import ScreenType
+
 if sys.version_info <= (3, 5):
     print("Error: Please run with python3")
     sys.exit(1)
@@ -73,16 +75,18 @@ def main(matrix, config_base):
     render.start()
 
     screen = data.get_screen_type()
-    if screen == "news":
-        __refresh_offday(render, data)
-    elif screen == "standings":
+    if screen == ScreenType.ALWAYS_NEWS:
+        __refresh_news(render, data)
+    elif screen == ScreenType.ALWAYS_STANDINGS:
         __refresh_standings(render, data)
+    elif screen == ScreenType.LEAGUE_OFFDAY or screen == ScreenType.PREFERRED_TEAM_OFFDAY:
+        __refresh_offday(render, data)
     else:
         __refresh_gameday(render, data)
 
 
-def __refresh_offday(render_thread, data):  # type: (threading.Thread, Data) -> None
-    debug.log("Main has selected the offday information to refresh")
+def __refresh_news(render_thread, data):  # type: (threading.Thread, Data) -> None
+    debug.log("Main has selected the news to refresh")
     while render_thread.is_alive():
         time.sleep(30)
         data.refresh_weather()
@@ -96,11 +100,20 @@ def __refresh_standings(render_thread, data):  # type: (threading.Thread, Data) 
             time.sleep(30)
             data.refresh_standings()
     else:
-        __refresh_offday(render_thread, data)
+        __refresh_news(render_thread, data)
+
+
+def __refresh_offday(render_thread, data):  # type: (threading.Thread, Data) -> None
+    debug.log("Main has selected the offday information to refresh")
+    while render_thread.is_alive():
+        time.sleep(30)
+        data.refresh_standings()
+        data.refresh_weather()
+        data.refresh_news_ticker()
 
 
 def __refresh_gameday(render_thread, data):  # type: (threading.Thread, Data) -> None
-    debug.log("Main has selected the game and schedule information to refresh")
+    debug.log("Main has selected the gameday information to refresh")
 
     starttime = time.time()
     promise_game = data.schedule.games_live()

--- a/main.py
+++ b/main.py
@@ -115,6 +115,7 @@ def __refresh_games(render_thread, data):  # type: (threading.Thread, Data) -> N
                 cont = True
             if data.config.news_no_games:
                 data.refresh_news_ticker()
+                data.refresh_weather()
                 cont = True
             if cont:
                 continue

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -56,7 +56,7 @@ class MainRenderer:
 
         if news and standings:
             while True:
-                self.__draw_news(timer_cond(STANDINGS_NEWS_SWITCH_TIME, refresh=self.data.config.scrolling_speed))
+                self.__draw_news(timer_cond(STANDINGS_NEWS_SWITCH_TIME))
                 self.__draw_standings(timer_cond(STANDINGS_NEWS_SWITCH_TIME))
         elif news:
             self.__draw_news(permanent_cond)
@@ -77,9 +77,7 @@ class MainRenderer:
         while True:
             if not self.data.schedule.games_live():
                 if self.data.config.news_no_games and self.data.config.standings_no_games:
-                    self.__draw_news(
-                        all_of(timer_cond(STANDINGS_NEWS_SWITCH_TIME, refresh=refresh_rate), self.no_games_cond)
-                    )
+                    self.__draw_news(all_of(timer_cond(STANDINGS_NEWS_SWITCH_TIME), self.no_games_cond))
                     self.__draw_standings(all_of(timer_cond(STANDINGS_NEWS_SWITCH_TIME), self.no_games_cond))
                     continue
                 elif self.data.config.news_no_games:
@@ -176,7 +174,6 @@ class MainRenderer:
     def __draw_news(self, cond: Callable[[], bool]):
         """
         Draw the news screen for as long as cond returns True
-        Redraws every `data.config.scrolling_speed` seconds
         """
         color = self.data.config.scoreboard_colors.color("default.background")
         while cond():
@@ -205,7 +202,6 @@ class MainRenderer:
     def __draw_standings(self, cond: Callable[[], bool]):
         """
         Draw the standings screen for as long as cond returns True
-        Redraws every second
         """
         if not self.data.standings.populated():
             return
@@ -277,15 +273,12 @@ def permanent_cond() -> bool:
     return True
 
 
-def timer_cond(seconds, refresh=1) -> Callable[[], bool]:
+def timer_cond(seconds) -> Callable[[], bool]:
     """Create a condition that is true for the specified number of seconds"""
-    curr = 0
+    end = time.time() + seconds
 
     def cond():
-        nonlocal curr
-        curr += refresh
-
-        return curr < seconds
+        return time.time() < end
 
     return cond
 

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -17,6 +17,7 @@ from renderers.games import teams
 # TODO(BMW) make configurable time?
 STANDINGS_NEWS_SWITCH_TIME = 120
 
+
 class MainRenderer:
     def __init__(self, matrix, data):
         self.matrix = matrix
@@ -40,7 +41,7 @@ class MainRenderer:
 
             # Out of season off days don't always return standings so fall back on the offday renderer
             debug.error("No standings data.  Falling back to news.")
-            self.__render_news()
+            self.__draw_news(permanent_cond)
         elif screen == ScreenType.LEAGUE_OFFDAY:
             self.__render_offday(team_offday=False)
         elif screen == ScreenType.PREFERRED_TEAM_OFFDAY:
@@ -63,8 +64,9 @@ class MainRenderer:
                 self.__draw_standings(timer_cond(STANDINGS_NEWS_SWITCH_TIME))
         elif news:
             self.__draw_news(permanent_cond)
-        elif teams:
+        else:
             self.__draw_standings(permanent_cond)
+            self.__draw_news(permanent_cond)  # fallback to news if no standings
 
     # Renders a game screen based on it's status
     # May also call draw_offday or draw_standings if there are no games
@@ -73,7 +75,9 @@ class MainRenderer:
         while True:
             if not self.data.schedule.games_live():
                 if self.data.config.news_no_games and self.data.config.standings_no_games:
-                    self.__draw_news(all_of(timer_cond(STANDINGS_NEWS_SWITCH_TIME, refresh=refresh_rate), self.no_games_cond))
+                    self.__draw_news(
+                        all_of(timer_cond(STANDINGS_NEWS_SWITCH_TIME, refresh=refresh_rate), self.no_games_cond)
+                    )
                     self.__draw_standings(all_of(timer_cond(STANDINGS_NEWS_SWITCH_TIME), self.no_games_cond))
                     continue
                 elif self.data.config.news_no_games:
@@ -286,6 +290,7 @@ def timer_cond(seconds, refresh=1) -> Callable[[], bool]:
 
 def all_of(*conds) -> Callable[[], bool]:
     """Create a condition that is true if all of the given conditions are true"""
+
     def cond():
         return all(c() for c in conds)
 

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -40,9 +40,9 @@ class MainRenderer:
 
     # Render an offday screen with the weather, clock and news
     def __render_offday(self) -> NoReturn:
-        self.__draw_offday(permanent_cond())
+        self.__draw_news(permanent_cond())
 
-    def __draw_offday(self, cond: Callable[[], bool]):
+    def __draw_news(self, cond: Callable[[], bool]):
         self.data.scrolling_finished = False
         self.scrolling_text_pos = self.canvas.width
         while cond():
@@ -137,11 +137,11 @@ class MainRenderer:
                 if self.data.config.news_no_games and self.data.config.standings_no_games:
                     # TODO make configurable time?
                     # also, using all_of here is maybe overkill
-                    self.__draw_offday(all_of(timer_cond(120), self.no_games_cond()))
+                    self.__draw_news(all_of(timer_cond(120), self.no_games_cond()))
                     self.__draw_standings(all_of(timer_cond(120), self.no_games_cond()))
                     continue
                 elif self.data.config.news_no_games:
-                    self.__draw_offday(self.no_games_cond())
+                    self.__draw_news(self.no_games_cond())
                 elif self.data.config.standings_no_games:
                     self.__draw_standings(self.no_games_cond())
 

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -37,11 +37,7 @@ class MainRenderer:
             self.__draw_news(permanent_cond)
         # display the standings
         elif screen == ScreenType.ALWAYS_STANDINGS:
-            self.__draw_standings(permanent_cond)
-
-            # Out of season off days don't always return standings so fall back on the offday renderer
-            debug.error("No standings data.  Falling back to news.")
-            self.__draw_news(permanent_cond)
+            self.__render_standings()
         elif screen == ScreenType.LEAGUE_OFFDAY:
             self.__render_offday(team_offday=False)
         elif screen == ScreenType.PREFERRED_TEAM_OFFDAY:
@@ -65,8 +61,14 @@ class MainRenderer:
         elif news:
             self.__draw_news(permanent_cond)
         else:
-            self.__draw_standings(permanent_cond)
-            self.__draw_news(permanent_cond)  # fallback to news if no standings
+            self.__render_standings()
+
+    def __render_standings(self) -> NoReturn:
+        self.__draw_standings(permanent_cond)
+
+        # Out of season off days don't always return standings so fall back on the news renderer
+        debug.error("No standings data.  Falling back to news.")
+        self.__draw_news(permanent_cond)
 
     # Renders a game screen based on it's status
     # May also call draw_offday or draw_standings if there are no games


### PR DESCRIPTION
This allows you to have `no_games_live` set for the news and weather screen, just like the current setting for standings.

If both are set, it will rotate between the two every couple minutes until games become live. 


This is accomplished with a kind of clever system where we can pass in conditions from the outside which control how long each screen is shown for.  This also starts to pave the way for a better overall rotation config. I'd love to eventually allow you to have a rotation which looks like this:

```
offday: [news]                                           # options: news, standings
no_games_live: [news, standings]                         # options: news, standings
gameday: [preferred_teams, news, standings, live_games]  # options: preferred_teams (never rotate during these except inning breaks), news, standings, followed_teams (teams you follow but don't want to become sticky like preferred teams), live_games (all other games)
```

Not sure if I'll have a go at implementing that here or later on. 