### PR TITLE
Add the ability to truncate team names to a desired length

### DIFF
--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -107,7 +107,10 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
     font = layout.font("teams.name.{}".format(homeaway))
     team_text = "{:3s}".format(team.abbrev.upper())
     if full_team_names:
-        team_text = "{:13s}".format(team.name)
+        truncate_length = 13
+        if layout.state_is_warmup() == False:
+            truncate_length = layout.coords("teams.name.{}".format(homeaway)).get("truncate", 13)
+        team_text = team.name[0:truncate_length]
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
 
 

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -107,9 +107,7 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
     font = layout.font("teams.name.{}".format(homeaway))
     team_text = "{:3s}".format(team.abbrev.upper())
     if full_team_names:
-        truncate_length = 13
-        if layout.state_is_warmup() == False:
-            truncate_length = layout.coords("teams.name.{}".format(homeaway)).get("truncate", 13)
+        truncate_length = layout.coords("teams.name.{}".format(homeaway)).get("truncate", 13)
         team_text = team.name[0:truncate_length]
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
 


### PR DESCRIPTION
Currently working on a 64x32 layout that uses the 5x7 font a lot more. Needed a way to specify a specific number of characters to allow for the team name (instead of just going to the short 3 character names). This will allow you to add a `truncate` key to the `teams.name.home` or `teams.name.away` key-paths in your coordinates file to specify a truncate length. If the key isn't found, it falls back to the previous default of 13 characters.