### PR TITLE
Workflow to require release branch to merge to master

### DIFF
--- a/.github/workflows/require_release_branch.yml
+++ b/.github/workflows/require_release_branch.yml
@@ -1,0 +1,14 @@
+name: Require release branch
+
+on:
+  pull_request:
+
+jobs:
+  check_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        if: github.base_ref == 'master' && github.head_ref != 'dev'
+        run: |
+          echo "ERROR: You can only merge to master from dev."
+          exit 1

--- a/.github/workflows/require_release_branch.yml
+++ b/.github/workflows/require_release_branch.yml
@@ -10,5 +10,5 @@ jobs:
       - name: Check branch
         if: github.base_ref == 'master' && github.head_ref != 'dev'
         run: |
-          echo "ERROR: You can only merge to master from dev."
+          echo "ERROR: You can only merge to master from dev. Contributors should point their PRs to the dev branch."
           exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
 It's easy, just do the work and submit a pull request. If it's a major feature, please log an issue first.
 
+Please point all PRs to the dev branch.
+
 In pull requests, please upload a screenshot of your board.

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+<!--
+REMINDER: PRs should point to the dev branch!
+
+Please provide details about this PR, including any issues it resolves. 
+-->


### PR DESCRIPTION
Ironically this PR needs to be pointed to master 🙃

This PR will add the workflow to prevent non `dev` branch merges to master. This workflow will be added as a branch protection rule for master, which can be overridden with specific permissions if there's an emergency fix required.

Should cut down on instances of accidental merges to master and will let contributors have better visibility into where they should branch from