### PR TITLE
Bump RGBME to 0.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ feedparser==6.0.10
 MLB_StatsAPI>=1.6.1
 Pillow==9.3.0
 pyowm==3.3.0
-RGBMatrixEmulator>=0.8.2
+RGBMatrixEmulator>=0.8.4
 tzlocal==4.2


### PR DESCRIPTION
Resolves #463

Emulator diff available here
https://github.com/ty-porter/RGBMatrixEmulator/commit/4e85981026deebabf548daf7e887696f7b5ef22b