### PR TITLE
Clean up schedule advancement logic

### DIFF
--- a/data/schedule.py
+++ b/data/schedule.py
@@ -18,7 +18,6 @@ class Schedule:
         self.date = self.__parse_today()
         self.starttime = time.time()
         self.current_idx = 0
-        self.preferred_over = False
         # all games for the day
         self.__all_games = []
         # the actual (filtered) schedule
@@ -102,7 +101,6 @@ class Schedule:
             not self.config.rotation_preferred_team_live_enabled
             and self.config.rotation_preferred_team_live_mid_inning
             and not self.is_offday_for_preferred_team()
-            and not self.preferred_over
         ):
             game_index = self._game_index_for_preferred_team()
             if game_index >= 0:  # we return -1 if no live games for preferred team
@@ -122,8 +120,7 @@ class Schedule:
                         self.current_idx = game_index
                         debug.log("Moving to preferred game, index: %d", self.current_idx)
                         return preferred_game
-                    if status.is_complete(preferred_game.status()):
-                        self.preferred_over = True
+
 
         self.current_idx = self.__next_game_index()
         return self.__current_game()

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -57,6 +57,7 @@ class Schedule:
                     if live_games:
                         games = live_games
 
+                self.current_idx %= len(games)
                 self._games = games
 
                 return UpdateStatus.SUCCESS
@@ -104,24 +105,25 @@ class Schedule:
             and not self.preferred_over
         ):
             game_index = self._game_index_for_preferred_team()
-            scheduled_game = self._games[game_index]
-            preferred_game = Game.from_scheduled(scheduled_game, self.config.delay_in_10s_of_seconds)
-            if preferred_game is not None:
-                debug.log(
-                    "Preferred Team's Game Status: %s, %s %d",
-                    preferred_game.status(),
-                    preferred_game.inning_state(),
-                    preferred_game.inning_number(),
-                )
+            if game_index >= 0:  # we return -1 if no live games for preferred team
+                scheduled_game = self._games[game_index]
+                preferred_game = Game.from_scheduled(scheduled_game, self.config.delay_in_10s_of_seconds)
+                if preferred_game is not None:
+                    debug.log(
+                        "Preferred Team's Game Status: %s, %s %d",
+                        preferred_game.status(),
+                        preferred_game.inning_state(),
+                        preferred_game.inning_number(),
+                    )
 
-                if status.is_live(preferred_game.status()) and not status.is_inning_break(
-                    preferred_game.inning_state()
-                ):
-                    self.current_idx = game_index
-                    debug.log("Moving to preferred game, index: %d", self.current_idx)
-                    return preferred_game
-                if status.is_complete(preferred_game.status()):
-                    self.preferred_over = True
+                    if status.is_live(preferred_game.status()) and not status.is_inning_break(
+                        preferred_game.inning_state()
+                    ):
+                        self.current_idx = game_index
+                        debug.log("Moving to preferred game, index: %d", self.current_idx)
+                        return preferred_game
+                    if status.is_complete(preferred_game.status()):
+                        self.preferred_over = True
 
         self.current_idx = self.__next_game_index()
         return self.__current_game()
@@ -129,13 +131,16 @@ class Schedule:
     def _game_index_for_preferred_team(self):
         if self.config.preferred_teams:
             team_name = data.teams.TEAM_FULL[self.config.preferred_teams[0]]
-            team_index = self.current_idx
-            team_idxs = [i for i, game in enumerate(self._games) if team_name in [game["away_name"], game["home_name"]]]
-            if len(team_idxs) > 0:
-                team_index = next((i for i in team_idxs if status.is_live(self._games[i]["status"])), team_idxs[0],)
-            return team_index
-        else:
-            return self.current_idx
+            return next(
+                (
+                    i
+                    for i, game in enumerate(self._games)
+                    if team_name in [game["away_name"], game["home_name"]] and status.is_live(game["status"])
+                ),
+                -1,  # no live games for preferred team
+            )
+
+        return -1  # no preferred team
 
     def __next_game_index(self):
         counter = self.current_idx + 1

--- a/data/status.py
+++ b/data/status.py
@@ -162,15 +162,12 @@ WARMUP = "Warmup"  # Live
 WRITING = "Writing"  # Other
 REVIEW = "Review"  # Not in json
 
-GAME_STATE_INNING_BREAK = [Inning.TOP, Inning.BOTTOM]
+GAME_STATE_INNING_LIVE = [Inning.TOP, Inning.BOTTOM]
 
 GAME_STATE_LIVE = [
     IN_PROGRESS,
     WARMUP,
     INSTANT_REPLAY,
-    GAME_OVER,
-    GAME_OVER_TIE_DECISION_BY_TIEBREAKER,
-    GAME_OVER_TIED,
     MANAGER_CHALLENGE,
     MANAGER_CHALLENGE_CATCHDROP_IN_OUTFIELD,
     MANAGER_CHALLENGE_CLOSE_PLAY_AT_1ST,
@@ -409,4 +406,4 @@ def is_fresh(status):
 
 def is_inning_break(inning_state):
     """Returns whether a game is in an inning break (mid/end). Pass in the inning state."""
-    return inning_state not in GAME_STATE_INNING_BREAK
+    return inning_state not in GAME_STATE_INNING_LIVE


### PR DESCRIPTION
I think this might fix #466, but I have yet to witness the issue on my own hardware so I can't fully recreate it.

A few tweaks:

1. Completed games are no longer considered "live" (we have a separate "fresh" status for them, anyway)
2. The `current_idx` is now updated if the list of games got shorter in a refresh
3. `_game_index_for_preferred_team` no longer returns `current_idx` if it fails to find a preferred game - it returns `-1`
4. Removed a flag which was set when the 'preferred game' ended (which almost certainly didn't do the right thing during double headers, anyway)

Number 3 above is the cause of the issue @ty-porter noted on discord with a game being labelled as 'preferred' when it never should have been. Any of them could cause #466, IMO.