### PR TITLE
Add option to display team record on game screen

### DIFF
--- a/coordinates/w128h32.json.example
+++ b/coordinates/w128h32.json.example
@@ -291,6 +291,17 @@
         "y": 10
       }
     },
+    "record": {
+      "_comment": "Offscreen by default.",
+      "away": {
+        "x": -10,
+        "y": -10
+      },
+      "home": {
+        "x": -10,
+        "y": -10
+      }
+    },
     "runs": {
       "runs_hits_errors": {
         "show": false,

--- a/coordinates/w128h32.json.example
+++ b/coordinates/w128h32.json.example
@@ -292,14 +292,16 @@
       }
     },
     "record": {
-      "_comment": "Offscreen by default.",
+      "enabled": false,
       "away": {
-        "x": -10,
-        "y": -10
+        "font_name": "4x6",
+        "x": 19,
+        "y": 7
       },
       "home": {
-        "x": -10,
-        "y": -10
+        "font_name": "4x6",
+        "x": 19,
+        "y": 17
       }
     },
     "runs": {

--- a/coordinates/w128h64.json.example
+++ b/coordinates/w128h64.json.example
@@ -272,14 +272,14 @@
       }
     },
     "record": {
-      "_comment": "Offscreen by default.",
+      "enabled": false,
       "away": {
-        "x": -10,
-        "y": -10
+        "x": 30,
+        "y": 13
       },
       "home": {
-        "x": -10,
-        "y": -10
+        "x": 30,
+        "y": 29
       }
     },
     "runs": {

--- a/coordinates/w128h64.json.example
+++ b/coordinates/w128h64.json.example
@@ -271,6 +271,17 @@
         "y": 29
       }
     },
+    "record": {
+      "_comment": "Offscreen by default.",
+      "away": {
+        "x": -10,
+        "y": -10
+      },
+      "home": {
+        "x": -10,
+        "y": -10
+      }
+    },
     "runs": {
       "runs_hits_errors": {
         "show": true,

--- a/coordinates/w192h64.json.example
+++ b/coordinates/w192h64.json.example
@@ -272,14 +272,14 @@
       }
     },
     "record": {
-      "_comment": "Offscreen by default.",
+      "enabled": false,
       "away": {
-        "x": -10,
-        "y": -10
+        "x": 30,
+        "y": 13
       },
       "home": {
-        "x": -10,
-        "y": -10
+        "x": 30,
+        "y": 29
       }
     },
     "runs": {

--- a/coordinates/w192h64.json.example
+++ b/coordinates/w192h64.json.example
@@ -271,6 +271,17 @@
         "y": 29
       }
     },
+    "record": {
+      "_comment": "Offscreen by default.",
+      "away": {
+        "x": -10,
+        "y": -10
+      },
+      "home": {
+        "x": -10,
+        "y": -10
+      }
+    },
     "runs": {
       "runs_hits_errors": {
         "show": true,

--- a/coordinates/w32h32.json.example
+++ b/coordinates/w32h32.json.example
@@ -278,6 +278,17 @@
         "y": 13
       }
     },
+    "record": {
+      "_comment": "Offscreen by default.",
+      "away": {
+        "x": -10,
+        "y": -10
+      },
+      "home": {
+        "x": -10,
+        "y": -10
+      }
+    },
     "runs": {
       "runs_hits_errors": {
         "show": false,

--- a/coordinates/w32h32.json.example
+++ b/coordinates/w32h32.json.example
@@ -279,14 +279,14 @@
       }
     },
     "record": {
-      "_comment": "Offscreen by default.",
+      "enabled": false,
       "away": {
-        "x": -10,
-        "y": -10
+        "x": 4,
+        "y": 6
       },
       "home": {
-        "x": -10,
-        "y": -10
+        "x": 4,
+        "y": 13
       }
     },
     "runs": {

--- a/coordinates/w64h32.json.example
+++ b/coordinates/w64h32.json.example
@@ -264,14 +264,14 @@
       }
     },
     "record": {
-      "_comment": "Offscreen by default.",
+      "enabled": false,
       "away": {
-        "x": -10,
-        "y": -10
+        "x": 15,
+        "y": 6
       },
       "home": {
-        "x": -10,
-        "y": -10
+        "x": 15,
+        "y": 13
       }
     },
     "runs": {

--- a/coordinates/w64h32.json.example
+++ b/coordinates/w64h32.json.example
@@ -263,6 +263,17 @@
         "y": 7
       }
     },
+    "record": {
+      "_comment": "Offscreen by default.",
+      "away": {
+        "x": -10,
+        "y": -10
+      },
+      "home": {
+        "x": -10,
+        "y": -10
+      }
+    },
     "runs": {
       "runs_hits_errors": {
         "show": true,

--- a/coordinates/w64h64.json.example
+++ b/coordinates/w64h64.json.example
@@ -247,16 +247,17 @@
         "y": 10
       }
     },
-    ,
     "record": {
-      "_comment": "Offscreen by default.",
+      "enabled": false,
       "away": {
-        "x": -10,
-        "y": -10
+        "font_name": "4x6",
+        "x": 18,
+        "y": 7
       },
       "home": {
-        "x": -10,
-        "y": -10
+        "font_name": "4x6",
+        "x": 18,
+        "y": 17
       }
     },
     "runs": {

--- a/coordinates/w64h64.json.example
+++ b/coordinates/w64h64.json.example
@@ -247,6 +247,18 @@
         "y": 10
       }
     },
+    ,
+    "record": {
+      "_comment": "Offscreen by default.",
+      "away": {
+        "x": -10,
+        "y": -10
+      },
+      "home": {
+        "x": -10,
+        "y": -10
+      }
+    },
     "runs": {
       "runs_hits_errors": {
         "show": false,

--- a/data/game.py
+++ b/data/game.py
@@ -10,7 +10,7 @@ from data.delay_buffer import CircularQueue
 
 API_FIELDS = (
     "gameData,game,id,datetime,dateTime,officialDate,flags,noHitter,perfectGame,status,detailedState,abstractGameState,"
-    + "reason,probablePitchers,teams,home,away,abbreviation,teamName,players,id,boxscoreName,fullName,liveData,plays,"
+    + "reason,probablePitchers,teams,home,away,abbreviation,teamName,record,wins,losses,players,id,boxscoreName,fullName,liveData,plays,"
     + "currentPlay,result,eventType,playEvents,isPitch,pitchData,startSpeed,details,type,code,description,decisions,"
     + "winner,loser,save,id,linescore,outs,balls,strikes,note,inningState,currentInning,currentInningOrdinal,offense,"
     + "batter,inHole,onDeck,first,second,third,defense,pitcher,boxscore,teams,runs,players,seasonStats,pitching,wins,"
@@ -88,6 +88,12 @@ class Game:
 
     def home_abbreviation(self):
         return self._current_data["gameData"]["teams"]["home"]["abbreviation"]
+    
+    def home_record(self):
+        return self._current_data["gameData"]["teams"]["home"]["record"] or {}
+    
+    def away_record(self):
+        return self._current_data["gameData"]["teams"]["away"]["record"] or {}
 
     def pregame_weather(self):
         try:

--- a/data/scoreboard/__init__.py
+++ b/data/scoreboard/__init__.py
@@ -15,10 +15,10 @@ class Scoreboard:
 
     def __init__(self, game: Game):
         self.away_team = Team(
-            game.away_abbreviation(), game.away_score(), game.away_name(), game.away_hits(), game.away_errors()
+            game.away_abbreviation(), game.away_score(), game.away_name(), game.away_hits(), game.away_errors(), game.away_record()
         )
         self.home_team = Team(
-            game.home_abbreviation(), game.home_score(), game.home_name(), game.home_hits(), game.home_errors()
+            game.home_abbreviation(), game.home_score(), game.home_name(), game.home_hits(), game.home_errors(), game.home_record()
         )
         self.inning = Inning(game)
         self.bases = Bases(game)

--- a/data/scoreboard/team.py
+++ b/data/scoreboard/team.py
@@ -1,7 +1,8 @@
 class Team:
-    def __init__(self, abbrev, runs, name, hits, errors):
+    def __init__(self, abbrev, runs, name, hits, errors, record):
         self.abbrev = abbrev
         self.runs = runs
         self.name = name
         self.hits = hits
         self.errors = errors
+        self.record = record

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -116,6 +116,8 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
 def __render_record_text(canvas, layout, colors, team, homeaway, default_colors):
     if "losses" not in team.record or "wins" not in team.record:
         return
+    if not layout.coords("teams.record.enabled"):
+        return
 
     text_color = colors.get("text", default_colors["text"])
     text_color_graphic = graphics.Color(text_color["r"], text_color["g"], text_color["b"])

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -58,6 +58,9 @@ def render_team_banner(
     __render_team_text(canvas, layout, away_colors, away_team, "away", use_full_team_names, default_colors)
     __render_team_text(canvas, layout, home_colors, home_team, "home", use_full_team_names, default_colors)
 
+    __render_record_text(canvas, layout, away_colors, away_team, "away", default_colors)
+    __render_record_text(canvas, layout, home_colors, home_team, "home", default_colors)
+
     if show_score:
         # Number of characters in each score.
         score_spacing = {
@@ -109,6 +112,17 @@ def __render_team_text(canvas, layout, colors, team, homeaway, full_team_names, 
     if full_team_names:
         team_text = "{:13s}".format(team.name)
     graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, team_text)
+
+def __render_record_text(canvas, layout, colors, team, homeaway, default_colors):
+    if "losses" not in team.record or "wins" not in team.record:
+        return
+
+    text_color = colors.get("text", default_colors["text"])
+    text_color_graphic = graphics.Color(text_color["r"], text_color["g"], text_color["b"])
+    coords = layout.coords("teams.record.{}".format(homeaway))
+    font = layout.font("teams.record.{}".format(homeaway))
+    record_text = "({}-{})".format(team.record["wins"], team.record["losses"])
+    graphics.DrawText(canvas, font["font"], coords["x"], coords["y"], text_color_graphic, record_text)
 
 
 def __render_score_component(canvas, layout, colors, homeaway, default_colors, coords, component_val, width_chars):


### PR DESCRIPTION
Addresses #485

Still undergoing testing. This adds the layout keys needed to render the team record on the game screen. By default, the record will render off screen since it takes up quite a bit of space (8 max):

```
(WWW-LL)
12345678
```

Requested behavior can be achieved with a custom coordinates file and the following config setting:

```
 "full_team_names": false
```

Future enhancements may need to specify smaller font sizes to fit in smaller