### PR TITLE
Add virtual environment to install.sh

### DIFF
--- a/.git-config-template
+++ b/.git-config-template
@@ -1,0 +1,4 @@
+[filter "noshebang"]
+    clean = grep -v '.!/.*python3'
+    smudge = cat
+    required

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+main.py filter=noshebang

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ cd mlb-led-scoreboard/
 sudo ./install.sh
 ```
 
+This will create a Python Virtual Environment and install all of the required dependencies. The
+virtual environment will be located at `mlb-led-scoreboard/venv/`.
+
 This will install the rgbmatrix binaries, which we get from [another open source library](https://github.com/hzeller/rpi-rgb-led-matrix/tree/master/bindings/python#building). It controls the actual rendering of the scoreboard onto the LEDs. If you're curious, you can read through their documentation on how all of the lower level stuff works.
 
 It will also install the following python libraries that are required for certain parts of the scoreboard to function.
@@ -144,7 +147,7 @@ Additional flags are available for customizing your install:
 -c, --skip-config  Skips default config overwrite without prompting.
 
 -a, --skip-all     Performs all above skips.
-
+--no-venv          Do not create a virtual environment for the dependencies.
 --emulator-only    Do not install dependencies under sudo. Skips building matrix dependencies.
 
 -h, --help         Displays help
@@ -167,11 +170,14 @@ The latest version of the software is available [here](https://github.com/MLB-LE
 Make sure your Raspberry Pi's timezone is configured to your local time zone. They'll often have London time on them by default. You can change the timezone of your raspberry pi by running `sudo raspi-config`.
 
 ## Usage
-`sudo python3 main.py` Running as root is 100% an absolute must, or the matrix won't render.
+The installation script adds a line to the top of `main.py` to automatically pick up the virtual environment.
+This means re-activating the environment (`source ./venv/bin/activate`) is not a requirement.
+
+`sudo ./main.py` Running as root is 100% an absolute must, or the matrix won't render.
 
 **Adafruit HAT/Bonnet users: You must supply a command line flag:**
 
-`sudo python3 main.py --led-gpio-mapping="adafruit-hat"`
+`sudo ./main.py --led-gpio-mapping="adafruit-hat"`
 
 See the Flags section below for more flags you can optionally provide.
 
@@ -180,13 +186,13 @@ See the Flags section below for more flags you can optionally provide.
 The scoreboard can run on other platforms by means of software emulation via `RGBMatrixEmulator`. When running via the emulator, you do not need to prepend your startup commands with `sudo`:
 
 ```sh
-python3 main.py
+./main.py
 ```
 
 You can also force the scoreboard into emulation mode by using the `--emulated` flag:
 
 ```sh
-python3 main.py --emulated
+./main.py --emulated
 ```
 
 When running in emulation mode, you can continue to use your existing command line flags as normal.
@@ -262,7 +268,7 @@ A default `config.json.example` file is included for reference. Copy this file t
 * Pitch Data - Pitch data can be shown on the game screen, See the [coordinates readme file](/coordinates/README.md) for details. In addition, the `short` and `long` pitch description can be changed in data/pitches.py
 
 * Previous Play Data - Data for the previous play can be shown on the game screen. See the [coordinates readme file](/coordinates/README.md) for details. Long and short play descriptions can be changed in data/plays.py
-  * **NOTE:** Because play result data is ephemeral, not every play result will be displayed. Situations like a mound visit, injury, or other timeout immediately following a play often cause the play result to be immediately replaced on the MLB API. 
+  * **NOTE:** Because play result data is ephemeral, not every play result will be displayed. Situations like a mound visit, injury, or other timeout immediately following a play often cause the play result to be immediately replaced on the MLB API.
 
 ### Flags
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ usage() {
         -p, --skip-python:  Skip Python 3 installation. Requires manual Python 3 setup if not already installed.
 
         -a, --skip-all:     Skip all dependencies and config installation (equivalent to -c -p -m).
-
+        --no-venv           Do not create a virtual environment for the dependencies.
         --emulator-only:    Do not install dependencies under sudo. Skips building matrix dependencies (equivalent to -m)
 
 USAGE
@@ -22,6 +22,7 @@ SKIP_PYTHON=false
 SKIP_CONFIG=false
 SKIP_MATRIX=false
 NO_SUDO=false
+SKIP_VENV=false
 
 for arg in "$@"; do
     case $arg in
@@ -41,12 +42,17 @@ for arg in "$@"; do
         SKIP_CONFIG=true
         SKIP_MATRIX=true
         SKIP_PYTHON=true
+        SKIP_VENV=true
         shift # Remove -a / --skip-all from `$@`
         ;;
     --emulator-only)
         SKIP_MATRIX=true
         NO_SUDO=true
         shift # remove --emulator-only from `$@`
+        ;;
+    --no-venv)
+        SKIP_VENV=true
+        shift # remove --no-venv from `$@`
         ;;
     -h | --help)
         usage # run usage function on help
@@ -69,6 +75,7 @@ if [ "$SKIP_PYTHON" = false ]; then
         python3-pip \
         python3-pillow \
         python3-tk \
+        python3-venv \
         libxml2-dev \
         libxslt-dev \
         libsdl2-mixer-2.0-0 \
@@ -84,10 +91,31 @@ echo "  Installing dependencies..."
 echo "------------------------------------"
 echo
 
+if [ "$SKIP_VENV" = false ]; then
+    echo "Creating virtual environment..."
+    if [ "$NO_SUDO" = false ]; then
+        sudo python3 -m venv ./venv
+    else
+        python3 -m venv ./venv
+    fi
+    source ./venv/bin/activate
+
+
+    if ! grep -q "#\!/" main.py; then
+        if [ "$NO_SUDO" = false ]; then
+            sed  -i "1i #\!/usr/bin/sudo $(which python3)" main.py
+        else
+            sed  -i "1i #\!$(which python3)" main.py
+        fi
+        chmod +x main.py
+    fi
+fi
+PYTHON=$(which python3)
+
 if [ "$NO_SUDO" = false ]; then
-    sudo python3 -m pip install -r requirements.txt
+    sudo "$PYTHON" -m pip install -r requirements.txt
 else
-    python3 -m pip install -r requirements.txt
+    "$PYTHON" -m pip install -r requirements.txt
 fi
 
 if [ "$SKIP_MATRIX" = false ]; then
@@ -97,8 +125,8 @@ if [ "$SKIP_MATRIX" = false ]; then
     git clone https://github.com/hzeller/rpi-rgb-led-matrix.git matrix
     cd matrix
     git pull
-    make build-python PYTHON=$(which python3)
-    sudo make install-python PYTHON=$(which python3)
+    make build-python PYTHON="$PYTHON"
+    sudo make install-python PYTHON="$PYTHON"
 
     cd ../..
 fi
@@ -123,7 +151,7 @@ else
     echo "  update them with the latest options at this time."
     echo
     echo "  This operation is automatic and will ensure you have up-to-date configuration."
-    echo 
+    echo
     echo "  This action will NOT override any custom configuration you already have unless"
     echo "  the option has been obsoleted and is no longer in use."
     echo "==================================================================================="

--- a/install.sh
+++ b/install.sh
@@ -108,6 +108,10 @@ if [ "$SKIP_VENV" = false ]; then
             sed  -i "1i #\!$(which python3)" main.py
         fi
         chmod +x main.py
+
+        if ! grep -q "noshebang" ./.git/config; then
+            cat .git-config-template >> .git/config
+        fi
     fi
 fi
 PYTHON=$(which python3)


### PR DESCRIPTION
This should fix the issue we're having with newer rasbians which have the `EXTERNALLY_MANAGED` pip setting enabled.

- Sets up a virtual environment
- Installs all dependencies there instead
- Adds a shebang to `main.py` which means you don't need to activate it every time. Instead of `python3 main.py`, you can just run `./main.py` now (not sure if this is great, since we can't gitignore the change it makes, but it's probably fine?)