### PR TITLE
Added apt command to install make

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,7 @@ fi
 
 if [ "$SKIP_MATRIX" = false ]; then
     echo "Running rgbmatrix installation..."
+    sudo apt-get install -y make
     mkdir submodules
     cd submodules
     git clone https://github.com/hzeller/rpi-rgb-led-matrix.git matrix


### PR DESCRIPTION
Some distros (including dietpi) do not have make installed by default.  Added command to install make if RGBmatrix is being installed.  