### PR TITLE
Do not drop root privilege when running in venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ You can configure your LED matrix with the same flags used in the [rpi-rgb-led-m
 --led-pwm-dither-bits     Time dithering of lower bits (Default: 0)
 --config                  Specify a configuration file name other, omitting json xtn (Default: config)
 --emulated                Force the scoreboard to run in software emulation mode.
+--drop-privileges         Force the matrix driver to drop root privileges after setup. (Default: false)
 ```
 
 ## Personalization

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ You can configure your LED matrix with the same flags used in the [rpi-rgb-led-m
 --led-pwm-dither-bits     Time dithering of lower bits (Default: 0)
 --config                  Specify a configuration file name other, omitting json xtn (Default: config)
 --emulated                Force the scoreboard to run in software emulation mode.
---drop-privileges         Force the matrix driver to drop root privileges after setup. (Default: false)
+--drop-privileges         Force the matrix driver to drop root privileges after setup. (Default: true)
 ```
 
 ## Personalization

--- a/utils.py
+++ b/utils.py
@@ -127,7 +127,7 @@ def args():
         const=True
     )
     parser.add_argument(
-        "--drop-privileges", action="store_false", help="Force the matrix driver to drop root privileges after setup."
+        "--drop-privileges", action="store_true", help="Force the matrix driver to drop root privileges after setup."
     )
     return parser.parse_args()
 

--- a/utils.py
+++ b/utils.py
@@ -126,6 +126,9 @@ def args():
         help="Force using emulator mode over default matrix display.",
         const=True
     )
+    parser.add_argument(
+        "--drop-privileges", action="store_false", help="Force the matrix driver to drop root privileges after setup."
+    )
     return parser.parse_args()
 
 
@@ -148,6 +151,7 @@ def led_matrix_options(args):
     options.scan_mode = args.led_scan_mode
     options.pwm_lsb_nanoseconds = args.led_pwm_lsb_nanoseconds
     options.led_rgb_sequence = args.led_rgb_sequence
+    options.drop_privileges = args.drop_privileges
 
     try:
         options.pixel_mapper_config = args.led_pixel_mapper


### PR DESCRIPTION
https://github.com/hzeller/rpi-rgb-led-matrix/tree/master/bindings/python#user

The matrix drops privileges from `root` to `daemon` after it starts up. This is causing all kinds of issues where the `daemon` user seemingly doesn't have read permissions on a lot of different files. It's also recommended to use absolute paths (fixed in #519 already)

Main symptom this works around is not being able to find a cert from `certifi` in the new virtual environment, causing the scoreboard to crash on startup

I tried tweaking permissions on `venv/*` but did not seem to have an effect. It's likely still a pathing issue that would be difficult to work around.

Others are noting similar issues in Pi OS Bookworm so we don't seem to be alone here.
https://github.com/hzeller/rpi-rgb-led-matrix/issues/1607


