### PR TITLE
Fix a crash if pitcher is completely unknown

### DIFF
--- a/data/scoreboard/postgame.py
+++ b/data/scoreboard/postgame.py
@@ -1,4 +1,5 @@
 from data.game import Game
+import debug
 
 PITCHER_UNKNOWN = "Unknown"
 
@@ -6,36 +7,44 @@ PITCHER_UNKNOWN = "Unknown"
 class Postgame:
     def __init__(self, game: Game):
 
-        winner_side = game.winning_team()
+        self.winning_pitcher = PITCHER_UNKNOWN
+        self.winning_pitcher_wins = 0
+        self.winning_pitcher_losses = 0
 
         winner = game.decision_pitcher_id("winner")
         if winner is not None:
-            self.winning_pitcher = game.full_name(winner)
-            self.winning_pitcher_wins = game.pitcher_stat(winner, "wins", winner_side)
-            self.winning_pitcher_losses = game.pitcher_stat(winner, "losses", winner_side)
-        else:
-            self.winning_pitcher = PITCHER_UNKNOWN
-            self.winning_pitcher_wins = 0
-            self.winning_pitcher_losses = 0
+            try:
+                winner_side = game.winning_team()
+                self.winning_pitcher = game.full_name(winner)
+                self.winning_pitcher_wins = game.pitcher_stat(winner, "wins", winner_side)
+                self.winning_pitcher_losses = game.pitcher_stat(winner, "losses", winner_side)
+            except:
+                debug.exception("Error getting winning pitcher stats")
+
+        self.save_pitcher = None
+        self.save_pitcher_saves = None
 
         save = game.decision_pitcher_id("save")
         if save is not None:
-            self.save_pitcher = game.full_name(save)
-            self.save_pitcher_saves = game.pitcher_stat(save, "saves", winner_side)
-        else:
-            self.save_pitcher = None
-            self.save_pitcher_saves = None
+            try:
+                self.save_pitcher = game.full_name(save)
+                self.save_pitcher_saves = game.pitcher_stat(save, "saves", winner_side)
+            except:
+                debug.exception("Error getting save pitcher stats")
 
+        self.losing_pitcher = PITCHER_UNKNOWN
+        self.losing_pitcher_wins = 0
+        self.losing_pitcher_losses = 0
         loser = game.decision_pitcher_id("loser")
         if loser is not None:
-            loser_side = game.losing_team()
-            self.losing_pitcher = game.full_name(loser)
-            self.losing_pitcher_wins = game.pitcher_stat(loser, "wins", loser_side)
-            self.losing_pitcher_losses = game.pitcher_stat(loser, "losses", loser_side)
-        else:
-            self.losing_pitcher = PITCHER_UNKNOWN
-            self.losing_pitcher_wins = 0
-            self.losing_pitcher_losses = 0
+            try:
+                loser_side = game.losing_team()
+                self.losing_pitcher = game.full_name(loser)
+                self.losing_pitcher_wins = game.pitcher_stat(loser, "wins", loser_side)
+                self.losing_pitcher_losses = game.pitcher_stat(loser, "losses", loser_side)
+            except:
+                debug.exception("Error getting losing pitcher stats")
+
 
         self.series_status = game.series_status()
 

--- a/data/scoreboard/pregame.py
+++ b/data/scoreboard/pregame.py
@@ -1,5 +1,5 @@
 import tzlocal
-
+import debug
 from data.game import Game
 from data.time_formats import TIME_FORMAT_12H
 
@@ -20,26 +20,30 @@ class Pregame:
 
         self.status = game.status()
 
+        self.away_starter = PITCHER_TBD
         away_id = game.probable_pitcher_id("away")
         if away_id is not None:
-            name = game.full_name(away_id)
-            wins = game.pitcher_stat(away_id, "wins", "away")
-            losses = game.pitcher_stat(away_id, "losses", "away")
-            era = game.pitcher_stat(away_id, "era", "away")
-            self.away_starter = "{} ({}-{} {} ERA)".format(name, wins, losses, era)
-        else:
-            self.away_starter = PITCHER_TBD
+            try:
+                name = game.full_name(away_id)
+                wins = game.pitcher_stat(away_id, "wins", "away")
+                losses = game.pitcher_stat(away_id, "losses", "away")
+                era = game.pitcher_stat(away_id, "era", "away")
+                self.away_starter = "{} ({}-{} {} ERA)".format(name, wins, losses, era)
+            except:
+                debug.exception("Error getting away starter stats")
 
+        self.home_starter = PITCHER_TBD
         home_id = game.probable_pitcher_id("home")
         if home_id is not None:
-            name = game.full_name(home_id)
-            wins = game.pitcher_stat(home_id, "wins", "home")
-            losses = game.pitcher_stat(home_id, "losses", "home")
-            era = game.pitcher_stat(home_id, "era", "home")
-            self.home_starter = "{} ({}-{} {} ERA)".format(name, wins, losses, era)
-        else:
-            self.home_starter = PITCHER_TBD
-
+            try:
+                name = game.full_name(home_id)
+                wins = game.pitcher_stat(home_id, "wins", "home")
+                losses = game.pitcher_stat(home_id, "losses", "home")
+                era = game.pitcher_stat(home_id, "era", "home")
+                self.home_starter = "{} ({}-{} {} ERA)".format(name, wins, losses, era)
+            except:
+                debug.exception("Error getting away starter stats")
+                
         self.national_broadcasts = game.broadcasts()
         self.series_status = game.series_status()
 


### PR DESCRIPTION
I think this was caused by some weirdness, but my board entered a boot loop earlier because a pitcher existed but didn't have a full name. The places we use this already have safe default values, so this just makes sure they are robust to exceptions.