### PR TITLE
Fixed missing ! for snd blacklist and added g++ and gcc for DietPi

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -129,7 +129,7 @@ fi
 
 if [ "$SKIP_MATRIX" = false ]; then
     echo "Running rgbmatrix installation..."
-    sudo apt-get install -y make
+    sudo apt-get install -y make gcc g++
     mkdir submodules
     cd submodules
     git clone https://github.com/hzeller/rpi-rgb-led-matrix.git matrix
@@ -143,7 +143,7 @@ if [ "$SKIP_MATRIX" = false ]; then
     echo "------------------------------------"
     echo "  Checking for snd_bcm2835"
     echo "------------------------------------"
-    if [ -f /etc/modprobe.d/blacklist-rgbmatrix.conf ]; then
+    if [ ! -f /etc/modprobe.d/blacklist-rgbmatrix.conf ]; then
         echo "Sound Blacklist File not found, Creating."
         echo "blacklist snd_bcm2835" | sudo tee /etc/modprobe.d/blacklist-rgbmatrix.conf
         sudo modprobe -r snd_bcm2835


### PR DESCRIPTION
Fixe the missing ! in the check for soundcard blacklist file.

Added install of gcc and g++ to the existing make install for RGB Matrix in install script.

Verified the current published branch works on dietpi with these changes.