### PR TITLE
Remove tests for deprecated Pythons, remove from README pill

### DIFF
--- a/.github/workflows/run_unittest_on_pr_open.yml
+++ b/.github/workflows/run_unittest_on_pr_open.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_unittest_on_pr_open.yml
+++ b/.github/workflows/run_unittest_on_pr_open.yml
@@ -25,4 +25,4 @@ jobs:
           pip install -r ./requirements.txt
       - name: Test with unittest
         run: |
-          python -m unittest discover -s ./tests  -p 'test_*.py'
+          python -m unittest discover -s ./tests -p 'test_*.py'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mlb-led-scoreboard
 
-![Current Version](https://img.shields.io/github/v/release/MLB-LED-Scoreboard/MLB-LED-Scoreboard) ![](https://img.shields.io/badge/python-3.8_%7C_3.9_%7C_3.10_%7C_3.11-blue)
+![Current Version](https://img.shields.io/github/v/release/MLB-LED-Scoreboard/MLB-LED-Scoreboard) ![](https://img.shields.io/badge/python-3.9+-blue)
 
 [![Join Discord](https://img.shields.io/badge/discord-join-green.svg)](https://discord.gg/FdD6ec9fdt)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 feedparser==6.0.10
+legacy-cgi # Required by feedparser on Python 3.13
 MLB_StatsAPI>=1.6.1
 Pillow>=10.0.1
 pyowm==3.3.0
 RGBMatrixEmulator>=0.8.4
-setuptools
+setuptools # Required by pyowm on Python 3.12
 tzlocal==4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 feedparser==6.0.10
-legacy-cgi # Required by feedparser on Python 3.13
+legacy-cgi; python_version >= "3.13"
 MLB_StatsAPI>=1.6.1
 Pillow>=10.0.1
 pyowm==3.3.0
 RGBMatrixEmulator>=0.8.4
-setuptools # Required by pyowm on Python 3.12
+setuptools; python_version >= "3.12"
 tzlocal==4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ MLB_StatsAPI>=1.6.1
 Pillow>=10.0.1
 pyowm==3.3.0
 RGBMatrixEmulator>=0.8.4
+setuptools
 tzlocal==4.2

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -397,7 +397,7 @@ class TestValidateConfigMethods(unittest.TestCase):
 
     self.assertRegex(
       format_change(change, color=TermColor.RED),
-      re.compile(f'\\033\[{TermColor.RED}.+\\033\[0m')
+      re.compile(fr'\033\[{TermColor.RED}.+\033\[0m')
     )
 
 


### PR DESCRIPTION
Removes support for 3.8, adds 3.12 and 3.13

Includes `setuptools` and `legacy-cgi` due to dependencies in `pyowm` and `feedparser` that do not have recent releases.

With new raw string syntax, updated a test that was throwing warnings.