### PR TITLE
Bump feedparser to 6.0.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-feedparser==6.0.10
-legacy-cgi; python_version >= "3.13"
+feedparser>=6.0.11
 MLB_StatsAPI>=1.6.1
 Pillow>=10.0.1
 pyowm==3.3.0


### PR DESCRIPTION
`feedparser` actually works on Python 3.13 assuming we're at 6.0.11 or higher