### PR TITLE
 Fall back to API data when team ID not recognized 

### DIFF
--- a/data/game.py
+++ b/data/game.py
@@ -85,10 +85,16 @@ class Game:
         return (len(self._data_wait_queue) - 1) * GAME_UPDATE_RATE
 
     def home_name(self):
-        return teams.TEAM_ID_NAME[self._current_data["gameData"]["teams"]["home"]["id"]]
+        return teams.TEAM_ID_NAME.get(
+            self._current_data["gameData"]["teams"]["home"]["id"],
+            self._current_data["gameData"]["teams"]["home"]["teamName"],
+        )
 
     def home_abbreviation(self):
-        return teams.TEAM_ID_ABBR[self._current_data["gameData"]["teams"]["home"]["id"]]
+        return teams.TEAM_ID_ABBR.get(
+            self._current_data["gameData"]["teams"]["home"]["id"],
+            self._current_data["gameData"]["teams"]["home"]["abbreviation"],
+        )
 
     def home_record(self):
         return self._current_data["gameData"]["teams"]["home"]["record"] or {}
@@ -112,10 +118,16 @@ class Game:
             return wx
 
     def away_name(self):
-        return teams.TEAM_ID_NAME[self._current_data["gameData"]["teams"]["away"]["id"]]
+        return teams.TEAM_ID_NAME.get(
+            self._current_data["gameData"]["teams"]["away"]["id"],
+            self._current_data["gameData"]["teams"]["away"]["teamName"],
+        )
 
     def away_abbreviation(self):
-        return teams.TEAM_ID_ABBR[self._current_data["gameData"]["teams"]["away"]["id"]]
+        return teams.TEAM_ID_ABBR.get(
+            self._current_data["gameData"]["teams"]["away"]["id"],
+            self._current_data["gameData"]["teams"]["away"]["abbreviation"],
+        )
 
     def status(self):
         return self._status["detailedState"]

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -75,7 +75,7 @@ class Schedule:
     def is_offday_for_preferred_team(self):
         if self.config.preferred_teams:
             return not any(
-                data.teams.TEAM_NAME_ID[self.config.preferred_teams[0]] in [game["away_id"], game["home_id"]]
+                data.teams.get_team_id(self.config.preferred_teams[0]) in [game["away_id"], game["home_id"]]
                 for game in self.__all_games  # only care if preferred team is actually in list
             )
         else:
@@ -128,7 +128,7 @@ class Schedule:
 
     def _game_index_for_preferred_team(self):
         if self.config.preferred_teams:
-            team_id = data.teams.TEAM_NAME_ID[self.config.preferred_teams[0]]
+            team_id = data.teams.get_team_id(self.config.preferred_teams[0])
             return next(
                 (
                     i
@@ -155,5 +155,5 @@ class Schedule:
 
     @staticmethod
     def __filter_list_of_games(games, filter_teams):
-        teams = set(data.teams.TEAM_NAME_ID[t] for t in filter_teams)
+        teams = set(data.teams.get_team_id(t) for t in filter_teams)
         return list(game for game in games if set([game["away_id"], game["home_id"]]).intersection(teams))

--- a/data/teams.py
+++ b/data/teams.py
@@ -75,7 +75,7 @@ TEAM_ID_NAME = {
 
 
 # Can be customized, but names in the config.json file must match
-TEAM_NAME_ID = {
+_TEAM_NAME_ID = {
     "Athletics": 133,
     "Pirates": 134,
     "Padres": 135,
@@ -107,3 +107,11 @@ TEAM_NAME_ID = {
     "Nationals": 120,
     "Mets": 121,
 }
+
+def get_team_id(team_name):
+    try:
+        return _TEAM_NAME_ID[team_name]
+    except KeyError:
+        # this function is only ever given user's config as input
+        # so we provide a more exact error message
+        raise ValueError(f"Unknown team name: {team_name}")

--- a/tests/test_data_up_to_date.py
+++ b/tests/test_data_up_to_date.py
@@ -26,7 +26,10 @@ class TestStoredDataUpToDate(unittest.TestCase):
         self.assertEqual(id_to_name, data.teams.TEAM_ID_NAME)
 
         name_to_id = {t["teamName"]: t["id"] for t in teams}
-        self.assertEqual(name_to_id, data.teams.TEAM_NAME_ID)
+        self.assertEqual(name_to_id, data.teams._TEAM_NAME_ID)
+
+    def test_team_handles_unknown(self):
+        self.assertRaisesRegex(ValueError, "Unknown team name: Atsros", data.teams.get_team_id, "Atsros")
 
     def test_pitches_complete(self):
         pitches = set(p["code"] for p in statsapi.meta("pitchTypes"))


### PR DESCRIPTION
Fixes #574

This still allows customization in teams.py, but uses the same data as before #556 if the id isn't found, like is common in exhibition games