### PR TITLE
Optimize scrolling text by trimming on both sides

### DIFF
--- a/renderers/scrollingtext.py
+++ b/renderers/scrollingtext.py
@@ -38,10 +38,13 @@ def render_text(canvas, x, y, width, font, text_color, bg_color, text, scroll_po
         graphics.DrawText(canvas, font["font"], scroll_pos, y, text_color, text)
 
         # draw one-letter boxes to left and right to hide previous and next letters
-        h = font["size"]["height"]
+        top = y + 1
+        bottom = top - font["size"]["height"]
         for xi in range(0, w):
-            graphics.DrawLine(canvas, x - xi, y + 1, x - xi, y + 1 - h, bg_color)
-            graphics.DrawLine(canvas, x + width + xi, y + 1, x + width + xi, y + 1 - h, bg_color)
+            left = x - xi - 1
+            graphics.DrawLine(canvas, left, top, left, bottom, bg_color)
+            right = x + width + xi
+            graphics.DrawLine(canvas, right, top, right, bottom, bg_color)
 
         return total_width
     else:

--- a/renderers/scrollingtext.py
+++ b/renderers/scrollingtext.py
@@ -13,19 +13,20 @@ def render_text(canvas, x, y, width, font, text_color, bg_color, text, scroll_po
         total_width = w * len(text)
         h = font["size"]["height"]
 
+        trimmed = text
         # Offscreen to the left, adjust by first character width
         if scroll_pos - x < 0:
-            adjustment = abs(scroll_pos - x + w) // w
-            text = text[adjustment:]
+            adjustment = abs(scroll_pos - x) // w
+            trimmed = text[adjustment:]
             if adjustment:
                 scroll_pos += w * adjustment
 
-        if len(text) == 0:
+        if len(trimmed) == 0:
             return 0
 
-        graphics.DrawText(canvas, font["font"], scroll_pos, y, text_color, text)
+        graphics.DrawText(canvas, font["font"], scroll_pos, y, text_color, trimmed)
 
-        for xi in range(x - w * 2, x):
+        for xi in range(x - w , x):
             graphics.DrawLine(canvas, xi, y + 1, xi, y + 1 - h, bg_color)
         for xi in range(x + width, canvas.width):
             graphics.DrawLine(canvas, xi, y + 1, xi, y + 1 - h, bg_color)
@@ -44,7 +45,3 @@ def __text_should_scroll(text, font, width):
 
 def __center_position(text, font, width, x):
     return center_text_position(text, abs(width // 2) + x, font["size"]["width"])
-
-
-def __glyph_device_width(font, glyph):
-    return font.bdf_font.glyph(glyph).meta["dwx0"]


### PR DESCRIPTION
We were already doing this to the left, but it's useful if we also do it on the right both to minimize what we're trying to draw but also to allow different scrolling texts to appear on the same horizontal line as each other.

After this PR, a scrolling text element only needs one character's width of empty space on either side of it. Here's a modified version of the homepage where I made these 'dead' zones visible:


![image preview](https://i.imgur.com/qIZtSDq.gif)


Compare this to the current behavior:

![old behavior](https://i.imgur.com/lJko1Uo.png)

I think this makes something like #547 much easier in the different possible layout options because it matters much less what order things will be drawn