### PR TITLE
Add independent loop point for due up batters

### DIFF
--- a/coordinates/w128h32.json.example
+++ b/coordinates/w128h32.json.example
@@ -59,6 +59,7 @@
           "y_start": 0,
           "y_end": 64
         },
+        "loop": 128,
         "leadoff": {
           "x": 67,
           "y": 16,

--- a/coordinates/w128h64.json.example
+++ b/coordinates/w128h64.json.example
@@ -60,6 +60,7 @@
           "y_start": 32,
           "y_end": 64
         },
+        "loop": 128,
         "leadoff": {
           "font_name": "7x13",
           "x": 64,

--- a/coordinates/w192h64.json.example
+++ b/coordinates/w192h64.json.example
@@ -60,6 +60,7 @@
           "y_start": 32,
           "y_end": 64
         },
+        "loop": 192,
         "leadoff": {
           "font_name": "7x13",
           "x": 64,

--- a/coordinates/w32h32.json.example
+++ b/coordinates/w32h32.json.example
@@ -59,6 +59,7 @@
           "y_start": 33,
           "y_end": 33
         },
+        "loop": 33,
         "leadoff": {
           "x": 33,
           "y": 33,

--- a/coordinates/w64h32.json.example
+++ b/coordinates/w64h32.json.example
@@ -59,6 +59,7 @@
           "y_start": 14,
           "y_end": 32
         },
+        "loop": 64,
         "leadoff": {
           "x": 32,
           "y": 20,

--- a/coordinates/w64h64.json.example
+++ b/coordinates/w64h64.json.example
@@ -56,6 +56,7 @@
         "divider": {
           "draw": false
         },
+        "loop": 64,
         "leadoff": {
           "x": 2,
           "y": 45,

--- a/renderers/games/game.py
+++ b/renderers/games/game.py
@@ -1,3 +1,4 @@
+from data import status
 from driver import graphics
 from data.config.color import Color
 from data.config.layout import Layout
@@ -14,7 +15,7 @@ from renderers.games import nohitter
 
 def render_live_game(canvas, layout: Layout, colors: Color, scoreboard: Scoreboard, text_pos, animation_time):
     pos = 0
-    if scoreboard.inning.state == Inning.TOP or scoreboard.inning.state == Inning.BOTTOM:
+    if not status.is_inning_break(scoreboard.inning.state):
         pos = _render_at_bat(
                 canvas,
                 layout,

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -144,7 +144,11 @@ class MainRenderer:
             else:
                 self.animation_time = 0
 
-            loop_point = self.data.config.layout.coords("atbat")["loop"]
+            if status.is_inning_break(scoreboard.inning.state):
+                loop_point = self.data.config.layout.coords("inning.break.due_up")["loop"]
+            else:
+                loop_point = self.data.config.layout.coords("atbat")["loop"]
+
             self.scrolling_text_pos = min(self.scrolling_text_pos, loop_point)
             pos = gamerender.render_live_game(
                 self.canvas, layout, colors, scoreboard, self.scrolling_text_pos, self.animation_time


### PR DESCRIPTION
Something I missed in #585. The current code is looping on wherever the loop x position is for the batter name, which is not necessarily a meaningful number here and leads to weird 'hitching' where the text appears to start in the middle during the second loop-around on some screens.