### PR TITLE
Issue #363: status text centered on w128

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,3 +3,7 @@ REMINDER: PRs should point to the dev branch!
 
 Please provide details about this PR, including any issues it resolves. 
 -->
+
+Resolves issue #363: “Postponed” status not centered on w128, maybe more
+- w128h64.json.example
+    - centered status text by changing x value to 64

--- a/coordinates/w128h64.json.example
+++ b/coordinates/w128h64.json.example
@@ -231,7 +231,7 @@
   },
   "status": {
     "text": {
-      "x": 56,
+      "x": 64,
       "y": 46,
       "short_text": false
     },


### PR DESCRIPTION
<!--
REMINDER: PRs should point to the dev branch!

Please provide details about this PR, including any issues it resolves. 
-->

This is my first real pull request so please let me know if I've done this correctly!

In w128h64.json.example, changed the status text x value from 56 to 64 so it's centered.

Before:
<img width="1036" alt="Issue_363_before" src="https://github.com/user-attachments/assets/074836e5-b070-472e-8ddb-39f7c22a09d7" />

After:
<img width="1032" alt="Issue_363_after" src="https://github.com/user-attachments/assets/246719d4-9c3f-4e39-841f-edecc8f705c7" />
