### PR TITLE
Refactor config items that belong in layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,28 +283,27 @@ A default `config.example.json` file is included for reference. Copy this file t
                                           Check out the OpenWeather documentation (https://openweathermap.org/current#name) for more info.
                                           Ex: `"Chicago,il,us"`
   "metric_units"                  Bool    Change the weather display to metric units (Celsius, m/s) instead of imperial (Fahrenheit, MPH).
+  "pregame"                       Bool    If enabled, will display the weather for the game's location on the pregame screen.
 
 "time_format"                     String  Sets the preferred hour format for displaying time. Accepted values are "12h" or "24h" depending on which you prefer.
 "end_of_day"                      String  A 24-hour time you wish to consider the end of the previous day before starting to display the current day's games. Uses local time from your Pi.
-"full_team_names"                 Bool    If enabled on a board width >= 64, displays the full team name on the scoreboard instead of their abbreviation. This config option is ignored on 32-wide boards.
-"short_team_names_for_runs_hits"  Bool    If full_team_names is enabled, will use abreviated team names when runs or hits > 9 to prevent overflow of long names into RHE.
 "scrolling_speed"                 Integer Sets how fast the scrolling text scrolls. Supports an integer between 0 and 6.
 "preferred_game_delay_multiplier" Integer This value multiplied by api_refresh_rate determines the preferred team update delay in seconds. Must be 0 or greater.
 "api_refresh_rate"                Integer Refresh the game data from the MLB API every X seconds.  Must be at least 3, default is 10.
-"pregame_weather"                 Bool    If enabled, will display the weather for the game's location on the pregame screen.
 "debug"                           Bool    Game and other debug data is written to your console.
 "demo_date"                       String  A date in the format YYYY-MM-DD from which to pull data to demonstrate the scoreboard. A value of `false` will disable demo mode.
 ```
 
 ### Delaying Board Update
-* The "preferred_game_delay_multiplier" will delay the update of your LED board to allow you to synchronize with the boroadcast feed.
+
+* The "preferred_game_delay_multiplier" will delay the update of your LED board to allow you to synchronize with the broadcast feed.
 * This value is MULTIPLIED times the api_refresh_rate value to determine the delay.  For example, preferred_game_delay_multiplier=2 with api_refresh_rate=5 will delay the game updates by 10 seconds.
 * There appears to be a lot of variability in broadcast delays across networks/teams/CDN's.
 * Please note, that if restarting the service with a delay, it will take the value of cycles set for the board to be in sync.  
 * If you set the * preferred_game_delay_multiplier=10 with api_refresh_rate=3, it will take 30-40 seconds for the buffer to fill and the board to delay.
 
 ### Additional Features
-* Runs/Hits/Errors - Runs are always shown on the games screen, but you can enable or adjust spacing of a "runs, hits, errors" display.  Take a look at the [coordinates readme file](/coordinates/README.md) for details.
+* Line score (RHE) - Runs are always shown on the games screen, but you can enable or adjust spacing of the line score display.  Take a look at the [coordinates readme file](/coordinates/README.md) for details.
 
 * Pitch Data - Pitch data can be shown on the game screen, See the [coordinates readme file](/coordinates/README.md) for details. In addition, the `short` and `long` pitch description can be changed in data/pitches.py
 
@@ -340,6 +339,7 @@ You can configure your LED matrix with the same flags used in the [rpi-rgb-led-m
 
 ## Personalization
 If you're feeling adventurous (and we highly encourage it!), the sections below outline how you can truly personalize your scoreboard and make it your own!
+
 ### Custom Board Layout
 You have the ability to customize the way things are placed on the board (maybe you would prefer to see scrolling text for a pregame a bit higher or lower). See the `coordinates/` directory for more information.
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,6 @@ A default `config.example.json` file is included for reference. Copy this file t
 ```
 
 ### Delaying Board Update
-
 * The "preferred_game_delay_multiplier" will delay the update of your LED board to allow you to synchronize with the broadcast feed.
 * This value is MULTIPLIED times the api_refresh_rate value to determine the delay.  For example, preferred_game_delay_multiplier=2 with api_refresh_rate=5 will delay the game updates by 10 seconds.
 * There appears to be a lot of variability in broadcast delays across networks/teams/CDN's.

--- a/README.md
+++ b/README.md
@@ -289,10 +289,16 @@ A default `config.example.json` file is included for reference. Copy this file t
 "end_of_day"                      String  A 24-hour time you wish to consider the end of the previous day before starting to display the current day's games. Uses local time from your Pi.
 "scrolling_speed"                 Integer Sets how fast the scrolling text scrolls. Supports an integer between 0 and 6.
 "sync_delay_seconds"              Integer Delays game updates to sychronize with broadcasts. May introduce delay before rendering live games. Must be at least 0, defaults to 0 (no delay).
-"api_refresh_rate"                Integer Refresh the game data from the MLB API every X seconds.  Must be at least 3, default is 10.
+"api_refresh_rate"                Integer Refresh the game data from the MLB API every X seconds. Must be at least 3, default is 10.
 "debug"                           Bool    Game and other debug data is written to your console.
 "demo_date"                       String  A date in the format YYYY-MM-DD from which to pull data to demonstrate the scoreboard. A value of `false` will disable demo mode.
 ```
+
+### Synchronizing with Broadcasts
+
+You can manually delay live game updates to synchronize the scoreboard to live broadcasts. The API is typically faster than video feeds, so you may wish to delay the scoreboard to compensate. You may specify the total delay via the `sync_delay_seconds` config option.
+
+Note that the actual delay may be slightly higher than your specified setting since it is dependent on the API refresh rate. Therefore you may want to slightly **decrease** the sync delay to compensate.
 
 ### Additional Features
 * Line score (RHE) - Runs are always shown on the games screen, but you can enable or adjust spacing of the line score display.  Take a look at the [coordinates readme file](/coordinates/README.md) for details.

--- a/README.md
+++ b/README.md
@@ -288,18 +288,11 @@ A default `config.example.json` file is included for reference. Copy this file t
 "time_format"                     String  Sets the preferred hour format for displaying time. Accepted values are "12h" or "24h" depending on which you prefer.
 "end_of_day"                      String  A 24-hour time you wish to consider the end of the previous day before starting to display the current day's games. Uses local time from your Pi.
 "scrolling_speed"                 Integer Sets how fast the scrolling text scrolls. Supports an integer between 0 and 6.
-"preferred_game_delay_multiplier" Integer This value multiplied by api_refresh_rate determines the preferred team update delay in seconds. Must be 0 or greater.
+"sync_delay_seconds"              Integer Delays game updates to sychronize with broadcasts. May introduce delay before rendering live games. Must be at least 0, defaults to 0 (no delay).
 "api_refresh_rate"                Integer Refresh the game data from the MLB API every X seconds.  Must be at least 3, default is 10.
 "debug"                           Bool    Game and other debug data is written to your console.
 "demo_date"                       String  A date in the format YYYY-MM-DD from which to pull data to demonstrate the scoreboard. A value of `false` will disable demo mode.
 ```
-
-### Delaying Board Update
-* The "preferred_game_delay_multiplier" will delay the update of your LED board to allow you to synchronize with the broadcast feed.
-* This value is MULTIPLIED times the api_refresh_rate value to determine the delay.  For example, preferred_game_delay_multiplier=2 with api_refresh_rate=5 will delay the game updates by 10 seconds.
-* There appears to be a lot of variability in broadcast delays across networks/teams/CDN's.
-* Please note, that if restarting the service with a delay, it will take the value of cycles set for the board to be in sync.  
-* If you set the * preferred_game_delay_multiplier=10 with api_refresh_rate=3, it will take 30-40 seconds for the buffer to fill and the board to delay.
 
 ### Additional Features
 * Line score (RHE) - Runs are always shown on the games screen, but you can enable or adjust spacing of the line score display.  Take a look at the [coordinates readme file](/coordinates/README.md) for details.

--- a/config.example.json
+++ b/config.example.json
@@ -43,7 +43,7 @@
 	},
 	"time_format": "12h",
 	"end_of_day": "00:00",
-	"preferred_game_delay_multiplier": 0,
+	"sync_delay_seconds": 0,
 	"api_refresh_rate" : 5,
 	"scrolling_speed": 2,
 	"debug": false,

--- a/config.example.json
+++ b/config.example.json
@@ -38,15 +38,13 @@
 	"weather": {
 		"apikey": "YOUR_API_KEY_HERE",
 		"location": "Chicago,il,us",
-		"metric_units": false
+		"metric_units": false,
+		"pregame": true
 	},
 	"time_format": "12h",
 	"end_of_day": "00:00",
-	"full_team_names": true,
-	"short_team_names_for_runs_hits": true,
 	"preferred_game_delay_multiplier": 0,
 	"api_refresh_rate" : 5,
-	"pregame_weather": true,
 	"scrolling_speed": 2,
 	"debug": false,
 	"demo_date": false

--- a/coordinates/README.md
+++ b/coordinates/README.md
@@ -18,10 +18,12 @@ Any scoreboard element that prints text can accept a `"font_name"` attribute. Su
 The layout can have a couple of different states where things are rendered differently. Adding an object named for the layout state and giving it the same properties from the parent object will change the positioning of that parent object only when that state is found. For instance, when a game enters the `Warmup` state, the text `Warmup` appears under the time and the scrolling text is moved down.
 * `warmup` will	only render on the `pregame` screen and appears when a game enters the `Warmup` status. This usually happens 15-20 minutes before a game begins.
 * `nohit` and `perfect_game` will only render on the live game screen and appears when a game returns that it is currently a no hitter or perfect game and the `innings_until_display` of `nohitter` has passed.
-* The `runs_hits_errors` section enables the addition of hits and errors to the game screen.  
-  * `show` turns this feature on or off.
+* The `line_score` section configures the line score (RHE) on the game screen.
+  * Runs are always displayed.
+  * `show_hits_and_errors` toggles displaying hits and errors.
   * `compress_digits` will reduce the space between digits when the number of runs or hits is > 9.
   * `spacing` is the number of pixels between the runs/hits and hits/errors.
+  * When the line score is high (greater than 3 total digits), use `teams.name.shorten_on_high_line_score` to shorten team names to prevent overflow.
 
 ## Pitch Data
 * `enabled` (true/false) Turn feature on/off

--- a/coordinates/w128h32.example.json
+++ b/coordinates/w128h32.example.json
@@ -280,6 +280,8 @@
       }
     },
     "name": {
+      "full": true,
+      "shorten_on_high_line_score": true,
       "away": {
         "x": 4,
         "y": 8
@@ -317,12 +319,10 @@
         "y": 17
       }
     },
-    "runs": {
-      "runs_hits_errors": {
-        "show": false,
-        "compress_digits": false,
-        "spacing": 3
-      },
+    "line_score": {
+      "show_hits_and_errors": false,
+      "compress_digits": false,
+      "spacing": 3,
       "away": {
         "x": 63,
         "y": 8

--- a/coordinates/w128h64.example.json
+++ b/coordinates/w128h64.example.json
@@ -272,6 +272,8 @@
       }
     },
     "name": {
+      "full": true,
+      "shorten_on_high_line_score": true,
       "away": {
         "font_name": "9x18B",
         "x": 4,
@@ -295,12 +297,10 @@
         "y": 29
       }
     },
-    "runs": {
-      "runs_hits_errors": {
-        "show": true,
-        "compress_digits": true,
-        "spacing": 5
-      },
+    "line_score": {
+      "show_hits_and_errors": true,
+      "compress_digits": true,
+      "spacing": 5,
       "away": {
         "font_name": "9x18B",
         "x": 126,

--- a/coordinates/w192h64.example.json
+++ b/coordinates/w192h64.example.json
@@ -272,6 +272,8 @@
       }
     },
     "name": {
+      "full": true,
+      "shorten_on_high_line_score": true,
       "away": {
         "font_name": "9x18B",
         "x": 4,
@@ -295,12 +297,10 @@
         "y": 29
       }
     },
-    "runs": {
-      "runs_hits_errors": {
-        "show": true,
-        "compress_digits": true,
-        "spacing": 9
-      },
+    "line_score": {
+      "show_hits_and_errors": true,
+      "compress_digits": true,
+      "spacing": 9,
       "away": {
         "font_name": "9x18B",
         "x": 190,

--- a/coordinates/w32h32.example.json
+++ b/coordinates/w32h32.example.json
@@ -281,6 +281,8 @@
       }
     },
     "name": {
+      "full": false,
+      "shorten_on_high_line_score": true,
       "away": {
         "x": 3,
         "y": 6
@@ -302,12 +304,10 @@
         "y": 13
       }
     },
-    "runs": {
-      "runs_hits_errors": {
-        "show": false,
-        "compress_digits": true,
-        "spacing": 2
-      },
+    "line_score": {
+      "show_hits_and_errors": false,
+      "compress_digits": true,
+      "spacing": 2,
       "away": {
         "x": 31,
         "y": 6

--- a/coordinates/w64h32.example.json
+++ b/coordinates/w64h32.example.json
@@ -253,6 +253,8 @@
       }
     },
     "name": {
+      "full": true,
+      "shorten_on_high_line_score": true,
       "away": {
         "x": 4,
         "y": 6
@@ -288,12 +290,10 @@
         "y": 13
       }
     },
-    "runs": {
-      "runs_hits_errors": {
-        "show": true,
-        "compress_digits": false,
-        "spacing": 3
-      },
+    "line_score": {
+      "show_hits_and_errors": true,
+      "compress_digits": false,
+      "spacing": 3,
       "away": {
         "x": 62,
         "y": 6

--- a/coordinates/w64h64.example.json
+++ b/coordinates/w64h64.example.json
@@ -236,6 +236,8 @@
       }
     },
     "name": {
+      "full": true,
+      "shorten_on_high_line_score": true,
       "away": {
         "x": 4,
         "y": 8
@@ -273,12 +275,10 @@
         "y": 17
       }
     },
-    "runs": {
-      "runs_hits_errors": {
-        "show": false,
-        "compress_digits": false,
-        "spacing": 3
-      },
+    "line_score": {
+      "show_hits_and_errors": false,
+      "compress_digits": false,
+      "spacing": 3,
       "away": {
         "x": 63,
         "y": 8

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -103,7 +103,7 @@ class Config:
         self.check_api_refresh_rate()
 
         # Set up update delay parameter
-        self.sync_amount = self.sync_delay_seconds / self.api_refresh_rate
+        self.sync_amount = self.sync_delay_seconds // self.api_refresh_rate
 
     def check_preferred_teams(self):
         if not isinstance(self.preferred_teams, str) and not isinstance(self.preferred_teams, list):

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -8,7 +8,7 @@ import debug
 from data import status
 from data.config.color import Color
 from data.config.layout import Layout
-from data.time_formats import TIME_FORMAT_12H, TIME_FORMAT_24H
+from data.time_formats import TIME_FORMAT_12H, TIME_FORMAT_24H, os_datetime_format
 from utils import deep_update
 
 SCROLLING_SPEEDS = [0.3, 0.2, 0.1, 0.075, 0.05, 0.025, 0.01]
@@ -36,7 +36,7 @@ class Config:
         self.news_ticker_mlb_news = json["news_ticker"]["mlb_news"]
         self.news_ticker_countdowns = json["news_ticker"]["countdowns"]
         self.news_ticker_date = json["news_ticker"]["date"]
-        self.news_ticker_date_format = json["news_ticker"]["date_format"]
+        self.news_ticker_date_format = os_datetime_format(json["news_ticker"]["date_format"])
         self.news_no_games = json["news_ticker"]["display_no_games_live"]
 
         # Display Standings

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -66,7 +66,7 @@ class Config:
         # Misc config options
         self.time_format = json["time_format"]
         self.end_of_day = json["end_of_day"]
-        self.preferred_game_delay_multiplier = json["preferred_game_delay_multiplier"]
+        self.sync_delay_seconds = json["sync_delay_seconds"]
         self.api_refresh_rate = json["api_refresh_rate"]
 
         self.debug = json["debug"]
@@ -102,6 +102,9 @@ class Config:
         self.check_delay()
         self.check_api_refresh_rate()
 
+        # Set up update delay parameter
+        self.sync_rate = self.sync_delay_seconds / self.api_refresh_rate
+
     def check_preferred_teams(self):
         if not isinstance(self.preferred_teams, str) and not isinstance(self.preferred_teams, list):
             debug.warning(
@@ -114,17 +117,17 @@ class Config:
             self.preferred_teams = [team]
 
     def check_delay(self):
-        if self.preferred_game_delay_multiplier < 0:
+        if self.sync_delay_seconds < 0:
             debug.warning(
-                "preferred_game_delay_multiplier should be a positive integer. Using default value of 0"
+                "sync_delay_seconds should be a positive integer. Using default value of 0"
             )
-            self.preferred_game_delay_multiplier = 0
-        if self.preferred_game_delay_multiplier != int(self.preferred_game_delay_multiplier):
+            self.sync_delay_seconds = 0
+        if self.sync_delay_seconds != int(self.sync_delay_seconds):
             debug.warning(
-                "preferred_game_delay_multiplier should be an integer."
-                f" Truncating to {int(self.preferred_game_delay_multiplier)}"
+                "sync_delay_seconds should be an integer."
+                f" Truncating to {int(self.sync_delay_seconds)}"
             )
-            self.preferred_game_delay_multiplier = int(self.preferred_game_delay_multiplier)
+            self.sync_delay_seconds = int(self.sync_delay_seconds)
 
     def check_api_refresh_rate(self):
         if self.api_refresh_rate < 3:

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -103,7 +103,7 @@ class Config:
         self.check_api_refresh_rate()
 
         # Set up update delay parameter
-        self.sync_rate = self.sync_delay_seconds / self.api_refresh_rate
+        self.sync_amount = self.sync_delay_seconds / self.api_refresh_rate
 
     def check_preferred_teams(self):
         if not isinstance(self.preferred_teams, str) and not isinstance(self.preferred_teams, list):

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -61,13 +61,11 @@ class Config:
         self.weather_apikey = json["weather"]["apikey"]
         self.weather_location = json["weather"]["location"]
         self.weather_metric_units = json["weather"]["metric_units"]
+        self.pregame_weather = json["weather"]["pregame"]
 
         # Misc config options
         self.time_format = json["time_format"]
         self.end_of_day = json["end_of_day"]
-        self.full_team_names = json["full_team_names"]
-        self.short_team_names_for_runs_hits = json["short_team_names_for_runs_hits"]
-        self.pregame_weather = json["pregame_weather"]
         self.preferred_game_delay_multiplier = json["preferred_game_delay_multiplier"]
         self.api_refresh_rate = json["api_refresh_rate"]
 

--- a/data/game.py
+++ b/data/game.py
@@ -38,11 +38,11 @@ class Game:
             return game
         return None
 
-    def __init__(self, game_id, date, broadcasts, series_status, sync_rate, api_refresh_rate):
+    def __init__(self, game_id, date, broadcasts, series_status, sync_amount, api_refresh_rate):
         self.game_id = game_id
         self.date = date
         self.starttime = time.time()
-        self._data_wait_queue = CircularQueue(sync_rate + 1)
+        self._data_wait_queue = CircularQueue(sync_amount + 1)
         self._current_data = {}
         self._broadcasts = broadcasts
         self._series_status = series_status

--- a/data/game.py
+++ b/data/game.py
@@ -38,11 +38,11 @@ class Game:
             return game
         return None
 
-    def __init__(self, game_id, date, broadcasts, series_status, preferred_game_delay_multiplier, api_refresh_rate):
+    def __init__(self, game_id, date, broadcasts, series_status, sync_rate, api_refresh_rate):
         self.game_id = game_id
         self.date = date
         self.starttime = time.time()
-        self._data_wait_queue = CircularQueue(preferred_game_delay_multiplier + 1)
+        self._data_wait_queue = CircularQueue(sync_rate + 1)
         self._current_data = {}
         self._broadcasts = broadcasts
         self._series_status = series_status

--- a/data/game.py
+++ b/data/game.py
@@ -22,7 +22,6 @@ API_FIELDS = (
 
 SCHEDULE_API_FIELDS = "dates,date,games,status,detailedState,abstractGameState,reason"
 
-GAME_UPDATE_RATE = 10
 
 class Game:
     @staticmethod

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -94,7 +94,7 @@ class Schedule:
             game_index = self._game_index_for_preferred_team()
             if game_index >= 0:  # we return -1 if no live games for preferred team
                 scheduled_game = self._games[game_index]
-                preferred_game = Game.from_scheduled(scheduled_game, self.config.sync_rate, self.config.api_refresh_rate)
+                preferred_game = Game.from_scheduled(scheduled_game, self.config.sync_amount, self.config.api_refresh_rate)
                 if preferred_game is not None:
                     debug.log(
                         "Preferred Team's Game Status: %s, %s %d",
@@ -139,7 +139,7 @@ class Schedule:
     def __current_game(self):
         if self._games:
             scheduled_game = self._games[self.current_idx]
-            return Game.from_scheduled(scheduled_game, self.config.sync_rate, self.config.api_refresh_rate)
+            return Game.from_scheduled(scheduled_game, self.config.sync_amount, self.config.api_refresh_rate)
         return None
 
     @staticmethod

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -94,7 +94,7 @@ class Schedule:
             game_index = self._game_index_for_preferred_team()
             if game_index >= 0:  # we return -1 if no live games for preferred team
                 scheduled_game = self._games[game_index]
-                preferred_game = Game.from_scheduled(scheduled_game, self.config.preferred_game_delay_multiplier, self.config.api_refresh_rate)
+                preferred_game = Game.from_scheduled(scheduled_game, self.config.sync_rate, self.config.api_refresh_rate)
                 if preferred_game is not None:
                     debug.log(
                         "Preferred Team's Game Status: %s, %s %d",
@@ -139,7 +139,7 @@ class Schedule:
     def __current_game(self):
         if self._games:
             scheduled_game = self._games[self.current_idx]
-            return Game.from_scheduled(scheduled_game, self.config.preferred_game_delay_multiplier, self.config.api_refresh_rate)
+            return Game.from_scheduled(scheduled_game, self.config.sync_rate, self.config.api_refresh_rate)
         return None
 
     @staticmethod

--- a/data/time_formats.py
+++ b/data/time_formats.py
@@ -1,4 +1,27 @@
 import platform
 
+
+WINDOWS_DISABLE_PADDING_SYMBOL = "#"
+DEFAULT_DISABLE_PADDING_SYMBOL = "-"
+
+def os_datetime_format(format_str):
+    '''
+    Converts Windows-based strftime() format code to a Unix code and vice versa.
+    For example, datetime.date(2025, 1, 1).strftime() with a format string '%Y %m %d'
+    left pads the month/day with zeros to two digits, resulting in '2025 01 01'.
+
+    Unix systems disable zero padding with '-', while Windows does so with '#'.
+    If the format string has an incompatible character, strftime() can fail.
+
+    The following format strings are equivalent, and both result in to '2025 1 1'.
+
+      Windows : '%Y %#m %#d'
+      Unix    : '%Y %-m %-d'
+    '''
+    if platform.system() == "Windows":
+        return format_str.replace(DEFAULT_DISABLE_PADDING_SYMBOL, WINDOWS_DISABLE_PADDING_SYMBOL)
+    else:
+        return format_str.replace(WINDOWS_DISABLE_PADDING_SYMBOL, DEFAULT_DISABLE_PADDING_SYMBOL)
+
+TIME_FORMAT_12H = os_datetime_format("%-I")
 TIME_FORMAT_24H = "%H"
-TIME_FORMAT_12H = "%#I" if platform.system() == "Windows" else "%-I"

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -162,8 +162,6 @@ class MainRenderer:
             self.data.config.team_colors,
             scoreboard.home_team,
             scoreboard.away_team,
-            self.data.config.full_team_names,
-            self.data.config.short_team_names_for_runs_hits,
             show_score=not status.is_pregame(game.status()),
         )
 

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -124,7 +124,7 @@ class TestValidateConfigMethods(unittest.TestCase):
         self.assertEqual(
           custom_config_files(),
           [
-            (ROOT_DIR, "config.json", { "ignored_keys": [], "renamed_keys": {"preferred_game_update_delay_in_10s_of_seconds": "preferred_game_delay_multiplier"} }),
+            (ROOT_DIR, "config.json", { "ignored_keys": [], "renamed_keys": {} }),
             (COORDINATES_DIR, "config.json", { "ignored_keys": COORDINATES_IGNORED_KEYS, "renamed_keys": {} }),
             (COLORS_DIR, "config.json", { "ignored_keys": COLORS_IGNORED_KEYS, "renamed_keys": {} }),
           ]

--- a/validate_config.py
+++ b/validate_config.py
@@ -7,9 +7,7 @@ COLORS_DIR      = os.path.join(ROOT_DIR, "colors")
 VALIDATIONS = {
   ROOT_DIR: {
     "ignored_keys": [],
-    "renamed_keys": {
-      "preferred_game_update_delay_in_10s_of_seconds": "preferred_game_delay_multiplier",
-    },
+    "renamed_keys": {},
   },
   COORDINATES_DIR: {
     "ignored_keys": [


### PR DESCRIPTION
This is a breaking change and requires a major version update.

We have a config validator that will prevent old configs from completely bombing, but writing these as deprecations (such as #427 and #602) will take a long time and increase the code complexity, I prefer to just rip the bandaid off with a major version bump in this case

**Changelog**

* `config.json`
  - `pregame_weather` moved to weather section (`weather.pregame`)
  - removed `full_team_names` (moved to coordinates)
  - removed `short_team_names_for_runs_hits` (moved to coordinates)
  - renamed `preferred_game_delay_multiplier` to `sync_delay_seconds` and significantly altered its functionality
    - This setting is now the TOTAL desired delay and the number of responses stored in the delay buffer is equal to this setting divided by API refresh rate plus 1
    - This simplifies end users calculating their desired sync

* `coordinates/wXhY.json`
  - added `teams.name.full` boolean
    - Replaces removed `full_team_names`  from `config.json`
    - Defaults to true:
      - 128x32
      - 128x64
      - 192x64
      - 64x32
      - 64x64
    - Defaults to false:
      - 32x32  
  - added `teams.name.shorten_on_high_line_score` boolean
    -  Replaces removed `short_team_names_for_runs_hits` from `config.json`
    - All sizes default to true
  - Changed `teams.runs` section to `teams.line_score`
    - Moved all `teams.runs.runs_hits_errors` subkeys to the `teams.line_score` section
      - ex: `teams.runs.runs_hits_errors.compress_digits` is now `teams.line_score.compress_digits`
    - Renamed `teams.runs.runs_hits_errors.show` to `teams.line_score.show_hits_and_errors`
    - Values are left unchanged