### PR TITLE
Fix city connects becoming sticky due to shallow copy

### DIFF
--- a/data/scoreboard/team.py
+++ b/data/scoreboard/team.py
@@ -24,7 +24,7 @@ class Team:
         try:
             colors = team_colors.color(self.abbrev.lower())
             if self.special_uniform is not None and self.special_uniform in colors:
-                colors |= colors[self.special_uniform]
+                colors = colors | colors[self.special_uniform]
             return default_colors | colors
 
         except KeyError:


### PR DESCRIPTION
This is why users who didn't restart their boards were observing odd behavior the next day. The underlying team_colors dict was being modified