### PR TITLE
Currently-Displayed Standings Indicator on bottom row

### DIFF
--- a/renderers/standings.py
+++ b/renderers/standings.py
@@ -44,6 +44,53 @@ def __render_rotating_standings(canvas, layout, colors, division, stat, league):
 
         offset += coords["offset"]
 
+    __render_standings_indicator(canvas, layout, colors, division, league)
+
+
+def __render_standings_indicator(canvas, layout, colors, division, league):
+    divider_color = get_standings_color_node(colors, "divider", league)
+    team_name_color = get_standings_color_node(colors, "team.name", league)
+
+    xMax = canvas.width
+    yMax = canvas.height
+    xMin = 0
+    xS = xMax-1
+    xH = int(xMax/2)
+    xt1 = xH / 3
+    xt2 = (xH / 3) * 2
+    yS = yMax-1
+
+    graphics.DrawLine(canvas, xMin, yS, xS, yS, divider_color)
+
+    if ("Wild Card" in division.name):
+        if ("AL" in division.name):
+            for x in range (xMin, xH):
+                if (x % 5) > 0:
+                    graphics.DrawLine(canvas, x, yS, x, yS, divider_color)
+                else:
+                    graphics.DrawLine(canvas, x, yS, x, yS, team_name_color)
+        else:
+            for x in range (xH, xMax):
+                if (x % 5) > 0:
+                    graphics.DrawLine(canvas, x, yS, x, yS, divider_color)
+                else:
+                    graphics.DrawLine(canvas, x, yS, x, yS, team_name_color)
+    if ("West" in division.name):
+        if ("AL" in division.name):
+            graphics.DrawLine(canvas, xMin, yS, xt1, yS, team_name_color)
+        else:
+            graphics.DrawLine(canvas, xMin+xH, yS, xt1+xH, yS, team_name_color)
+    elif ("Central" in division.name):
+        if ("AL" in division.name):
+            graphics.DrawLine(canvas, xt1, yS, xt2, yS, team_name_color)
+        else:
+            graphics.DrawLine(canvas, xt1+xH, yS, xt2+xH, yS, team_name_color)
+    elif ("East" in division.name):
+        if ("AL" in division.name):
+            graphics.DrawLine(canvas, xt2, yS, xH, yS, team_name_color)
+        else:
+            graphics.DrawLine(canvas, xt2+xH, yS, xS, yS, team_name_color)
+
 
 def __render_static_wide_standings(canvas, layout, colors, division, league):
     coords = layout.coords("standings")


### PR DESCRIPTION
Bottom row of LEDs modified to display divider_color, team_name_color then used for currently-displayed standings indicator:

1st Half = AL
2nd Half = NL

West = First 3rd (of half above)
Central = Middle 3rd (of half above)
East = Last 3rd (of half above)
Wild-Card = Wildly-spaced dots (of half above)

![IMG_7331](https://github.com/user-attachments/assets/15c8f59b-b24c-403a-987f-8933b8e72289)
![IMG_7333](https://github.com/user-attachments/assets/b32b75ca-fb26-489a-ad46-b6c99fd4d88f)
![IMG_7334](https://github.com/user-attachments/assets/389b4b30-c7a5-46eb-bc05-03a10be2a748)
![IMG_7335](https://github.com/user-attachments/assets/036c7a5e-868e-4956-8d56-29fcc70d75b2)
