### PR TITLE
Added ability to set headers on statsapi.game() requests

### DIFF
--- a/data/dates.py
+++ b/data/dates.py
@@ -7,11 +7,11 @@ import data.headers
 class Dates:
     def __init__(self, year: int):
         try:
-            data_d = statsapi.get("season", {"sportId": 1, "seasonId": year}, data.headers.API_HEADERS)
+            data_d = statsapi.get("season", {"sportId": 1, "seasonId": year}, request_kwargs={"headers": data.headers.API_HEADERS})
             self.__parse_important_dates(data_d["seasons"][0], year)
             now = datetime.now()
             if year == now.year and self.season_ends_date < now:
-                data_d = statsapi.get("season", {"sportId": 1, "seasonId": year + 1})
+                data_d = statsapi.get("season", {"sportId": 1, "seasonId": year + 1}, request_kwargs={"headers": data.headers.API_HEADERS})
                 self.__parse_important_dates(data_d["seasons"][0], year + 1)
         except:
             debug.exception("Failed to refresh important dates")

--- a/data/dates.py
+++ b/data/dates.py
@@ -1,19 +1,18 @@
 from datetime import datetime, timedelta
 
 import statsapi
-
 import debug
-
+import data.headers
 
 class Dates:
     def __init__(self, year: int):
         try:
-            data = statsapi.get("season", {"sportId": 1, "seasonId": year})
-            self.__parse_important_dates(data["seasons"][0], year)
+            data_d = statsapi.get("season", {"sportId": 1, "seasonId": year}, data.headers.API_HEADERS)
+            self.__parse_important_dates(data_d["seasons"][0], year)
             now = datetime.now()
             if year == now.year and self.season_ends_date < now:
-                data = statsapi.get("season", {"sportId": 1, "seasonId": year + 1})
-                self.__parse_important_dates(data["seasons"][0], year + 1)
+                data_d = statsapi.get("season", {"sportId": 1, "seasonId": year + 1})
+                self.__parse_important_dates(data_d["seasons"][0], year + 1)
         except:
             debug.exception("Failed to refresh important dates")
             self.playoffs_start_date = datetime(3000, 10, 1)

--- a/data/game.py
+++ b/data/game.py
@@ -54,7 +54,7 @@ class Game:
             self.starttime = time.time()
             try:
                 debug.log("Fetching data for game %s", str(self.game_id))
-                live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS}, request_kwargs={"headers": data.headers.API_HEADERS} | testing_params)
+                live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS}, testing_params, request_kwargs={"headers": data.headers.API_HEADERS} )
                 # we add a delay to avoid spoilers. During construction, this will still yield live data, but then
                 # it will recycle that data until the queue is full.
                 self._data_wait_queue.push(live_data)

--- a/data/game.py
+++ b/data/game.py
@@ -54,7 +54,7 @@ class Game:
             self.starttime = time.time()
             try:
                 debug.log("Fetching data for game %s", str(self.game_id))
-                live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS}, testing_params, request_kwargs={"headers": data.headers.API_HEADERS} )
+                live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS} | testing_params, request_kwargs={"headers": data.headers.API_HEADERS} )
                 # we add a delay to avoid spoilers. During construction, this will still yield live data, but then
                 # it will recycle that data until the queue is full.
                 self._data_wait_queue.push(live_data)

--- a/data/game.py
+++ b/data/game.py
@@ -54,9 +54,7 @@ class Game:
             self.starttime = time.time()
             try:
                 debug.log("Fetching data for game %s", str(self.game_id))
-                ########### need brians help with re-injecting the testing_params ###########
-                # live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS} | testing_params )
-                live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS}, data.headers.API_HEADERS)
+                live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS}, request_kwargs={"headers": data.headers.API_HEADERS} | testing_params)
                 # we add a delay to avoid spoilers. During construction, this will still yield live data, but then
                 # it will recycle that data until the queue is full.
                 self._data_wait_queue.push(live_data)
@@ -67,7 +65,7 @@ class Game:
                     debug.log("Getting game status from schedule for game with strange date!")
                     try:
                         scheduled = statsapi.get(
-                            "schedule", {"gamePk": self.game_id, "sportId": 1, "fields": SCHEDULE_API_FIELDS}, data.headers.API_HEADERS
+                            "schedule", {"gamePk": self.game_id, "sportId": 1, "fields": SCHEDULE_API_FIELDS}, request_kwargs={"headers": data.headers.API_HEADERS}
                         )
                         self._status = next(
                             g["games"][0]["status"] for g in scheduled["dates"] if g["date"] == self.date

--- a/data/game.py
+++ b/data/game.py
@@ -24,9 +24,6 @@ SCHEDULE_API_FIELDS = "dates,date,games,status,detailedState,abstractGameState,r
 
 GAME_UPDATE_RATE = 10
 
-debug.log("API HEADERS game.py line 26 %s", str(data.headers.API_HEADERS))
-                
-
 class Game:
     @staticmethod
     def from_scheduled(game_data, delay) -> Optional["Game"]:

--- a/data/headers.py
+++ b/data/headers.py
@@ -1,0 +1,14 @@
+# Headers to be sent on each statsapi.get()
+# call.
+
+# TODO (NMS): Detect rpi hardware.  Inject gzip headers only for
+#             rpi's >=3 or emulator.
+
+
+API_HEADERS = """request_kwargs=
+{"headers": 
+    {
+        'Accept-Encoding': 'gzip',
+        'User-Agent': 'MLB-LED-Scoreboard',
+    }
+}"""

--- a/data/headers.py
+++ b/data/headers.py
@@ -1,11 +1,15 @@
 # Headers to be sent on each statsapi.get()
 # call.
 
+import version
+
 # TODO (NMS): Detect rpi hardware.  Inject gzip headers only for
 #             rpi's >=3 or emulator.
 
 
+
+
 API_HEADERS = {
     'Accept-Encoding': 'gzip',
-    'User-Agent': 'MLB-LED-Scoreboard',
+    'User-Agent': 'MLB-LED-Scoreboard/' + version.SCRIPT_VERSION,
 }

--- a/data/headers.py
+++ b/data/headers.py
@@ -5,10 +5,7 @@
 #             rpi's >=3 or emulator.
 
 
-API_HEADERS = """request_kwargs=
-{"headers": 
-    {
-        'Accept-Encoding': 'gzip',
-        'User-Agent': 'MLB-LED-Scoreboard',
-    }
-}"""
+API_HEADERS = {
+    'Accept-Encoding': 'gzip',
+    'User-Agent': 'MLB-LED-Scoreboard',
+}

--- a/data/standings.py
+++ b/data/standings.py
@@ -6,6 +6,7 @@ import statsapi
 import debug
 from data import teams
 from data.update import UpdateStatus
+import data.headers
 
 STANDINGS_UPDATE_RATE = 15 * 60  # 15 minutes between standings updates
 
@@ -50,7 +51,7 @@ class Standings:
                     if self.date != datetime.today().date():
                         season_params["date"] = self.date.strftime("%m/%d/%Y")
 
-                    divisons_data = statsapi.get("standings", season_params)
+                    divisons_data = statsapi.get("standings", season_params, data.headers.API_HEADERS)
                     standings = [Division(division_data) for division_data in divisons_data["records"]]
 
                     if self.wild_cards:
@@ -68,6 +69,7 @@ class Standings:
                             "hydrate": "league,team",
                             "fields": "series,id,gameType,games,description,teams,home,away,team,isWinner,name",
                         },
+                        data.headers.API_HEADERS
                     )
                     self.leagues["AL"] = League(postseason_data, "AL")
                     self.leagues["NL"] = League(postseason_data, "NL")

--- a/data/standings.py
+++ b/data/standings.py
@@ -51,12 +51,12 @@ class Standings:
                     if self.date != datetime.today().date():
                         season_params["date"] = self.date.strftime("%m/%d/%Y")
 
-                    divisons_data = statsapi.get("standings", season_params, data.headers.API_HEADERS)
+                    divisons_data = statsapi.get("standings", season_params, request_kwargs={"headers": data.headers.API_HEADERS})
                     standings = [Division(division_data) for division_data in divisons_data["records"]]
 
                     if self.wild_cards:
                         season_params["standingsTypes"] = "wildCard"
-                        wc_data = statsapi.get("standings", season_params)
+                        wc_data = statsapi.get("standings", season_params, request_kwargs={"headers": data.headers.API_HEADERS})
                         standings += [Division(data, wc=True) for data in wc_data["records"]]
 
                     self.standings = standings
@@ -69,7 +69,7 @@ class Standings:
                             "hydrate": "league,team",
                             "fields": "series,id,gameType,games,description,teams,home,away,team,isWinner,name",
                         },
-                        data.headers.API_HEADERS
+                        request_kwargs={"headers": data.headers.API_HEADERS}
                     )
                     self.leagues["AL"] = League(postseason_data, "AL")
                     self.leagues["NL"] = League(postseason_data, "NL")

--- a/data/uniforms.py
+++ b/data/uniforms.py
@@ -2,6 +2,7 @@ import time
 import statsapi
 
 import debug
+import data.headers
 
 API_FIELDS = "uniforms,home,away,uniformAssets,uniformAssetText"
 
@@ -37,10 +38,10 @@ class Uniforms:
             return
 
         try:
-            data = statsapi.get("game_uniforms", {"gamePks": self.game_id, "fields": API_FIELDS})["uniforms"][0]
+            data_u = statsapi.get("game_uniforms", {"gamePks": self.game_id, "fields": API_FIELDS}, data.headers.API_HEADERS)["uniforms"][0]
             for uniform, special_check in SPECIAL_UNIFORMS.items():
-                home_uniforms = data.get("home", {}).get("uniformAssets", [])
-                away_uniforms = data.get("away", {}).get("uniformAssets", [])
+                home_uniforms = data_u.get("home", {}).get("uniformAssets", [])
+                away_uniforms = data_u.get("away", {}).get("uniformAssets", [])
 
                 if not self.home_special and any(
                     special_check(asset["uniformAssetText"]) for asset in home_uniforms

--- a/data/uniforms.py
+++ b/data/uniforms.py
@@ -38,7 +38,7 @@ class Uniforms:
             return
 
         try:
-            data_u = statsapi.get("game_uniforms", {"gamePks": self.game_id, "fields": API_FIELDS}, data.headers.API_HEADERS)["uniforms"][0]
+            data_u = statsapi.get("game_uniforms", {"gamePks": self.game_id, "fields": API_FIELDS}, request_kwargs={"headers": data.headers.API_HEADERS})["uniforms"][0]
             for uniform, special_check in SPECIAL_UNIFORMS.items():
                 home_uniforms = data_u.get("home", {}).get("uniformAssets", [])
                 away_uniforms = data_u.get("away", {}).get("uniformAssets", [])

--- a/main.py
+++ b/main.py
@@ -36,6 +36,12 @@ from version import SCRIPT_NAME, SCRIPT_VERSION
 
 def main(matrix, config_base):
 
+    # Uncomment the below to get debug information on headers and requests
+    # from http.client import HTTPConnection
+    # HTTPConnection.debuglevel = 1
+    # import logging
+    # logging.basicConfig(level=logging.DEBUG)
+
     # Read scoreboard options from config.json if it exists
     config = Config(config_base, matrix.width, matrix.height)
     logger = logging.getLogger("mlbled")

--- a/tests/test_data_up_to_date.py
+++ b/tests/test_data_up_to_date.py
@@ -3,7 +3,7 @@ import statsapi
 import data.status
 import data.teams
 import data.pitches
-
+import data.headers
 
 class TestStoredDataUpToDate(unittest.TestCase):
     def test_status_complete(self):
@@ -17,7 +17,7 @@ class TestStoredDataUpToDate(unittest.TestCase):
         self.assertSetEqual(official_statuses, our_statuses)
 
     def test_teams_complete(self):
-        teams = statsapi.get("teams", {"sportIds": 1})["teams"]
+        teams = statsapi.get("teams", {"sportIds": 1}, request_kwargs={"headers": data.headers.API_HEADERS})["teams"]
 
         id_to_abbr = {t["id"]: t["abbreviation"] for t in teams}
         self.assertEqual(id_to_abbr, data.teams.TEAM_ID_ABBR)


### PR DESCRIPTION
Added data.headers with a constant API HEADERS.  Updated the statsapi.game() requests in 

```
data/dates.py
data/game.py
data/standings.py
data/teams.py
data/unifiorms.py
```

Need Brian Ward to take a look at the main game.py requests and replace his `testing_params`

I'm honestly not sure how to test that were actually sending the correct headers