### PR TITLE
Make API refresh rate configurable v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ A default `config.example.json` file is included for reference. Copy this file t
 "short_team_names_for_runs_hits" Bool    If full_team_names is enabled, will use abreviated team names when runs or hits > 9 to prevent overflow of long names into RHE.
 "scrolling_speed"                Integer Sets how fast the scrolling text scrolls. Supports an integer between 0 and 6.
 "preferred_game_update_delay_in_10s_of_seconds" Integer Sets how long to wait before updating the preferred game. Must be positive.
+"api_refresh_rate"               Integer >= 3.  Refresh the game data from the MLB API every X seconds.  Must be at least 3, default is 10.
 "pregame_weather"                Bool    If enabled, will display the weather for the game's location on the pregame screen.
 "debug"                          Bool    Game and other debug data is written to your console.
 "demo_date"                      String  A date in the format YYYY-MM-DD from which to pull data to demonstrate the scoreboard. A value of `false` will disable demo mode.

--- a/config.example.json
+++ b/config.example.json
@@ -45,6 +45,7 @@
 	"full_team_names": true,
 	"short_team_names_for_runs_hits": true,
 	"preferred_game_update_delay_in_10s_of_seconds": 0,
+	"api_refresh_rate" : 5,
 	"pregame_weather": true,
 	"scrolling_speed": 2,
 	"debug": false,

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -69,6 +69,7 @@ class Config:
         self.short_team_names_for_runs_hits = json["short_team_names_for_runs_hits"]
         self.pregame_weather = json["pregame_weather"]
         self.delay_in_10s_of_seconds = json["preferred_game_update_delay_in_10s_of_seconds"]
+        self.api_refresh_rate = json["api_refresh_rate"]
 
         self.debug = json["debug"]
         self.demo_date = json["demo_date"]
@@ -101,6 +102,7 @@ class Config:
         # Check the rotation_rates to make sure it's valid and not silly
         self.check_rotate_rates()
         self.check_delay()
+        self.check_api_refresh_rate()
 
     def check_preferred_teams(self):
         if not isinstance(self.preferred_teams, str) and not isinstance(self.preferred_teams, list):
@@ -125,6 +127,19 @@ class Config:
                 f" Truncating to {int(self.delay_in_10s_of_seconds)}"
             )
             self.delay_in_10s_of_seconds = int(self.delay_in_10s_of_seconds)
+
+    def check_api_refresh_rate(self):
+        if self.api_refresh_rate < 3:
+            debug.warning(
+                "api_refresh_rate should be a positive integer greater than 2. Using default value of 10"
+            )
+            self.api_refresh_rate = 10
+        if self.api_refresh_rate != int(self.api_refresh_rate):
+            debug.warning(
+                "api_refresh_rate should be an integer."
+                f" Truncating to {int(self.api_refresh_rate)}"
+            )
+            self.api_refresh_rate = int(self.api_refresh_rate)
 
     def check_preferred_divisions(self):
         if not isinstance(self.preferred_divisions, str) and not isinstance(self.preferred_divisions, list):

--- a/data/game.py
+++ b/data/game.py
@@ -26,19 +26,20 @@ GAME_UPDATE_RATE = 10
 
 class Game:
     @staticmethod
-    def from_scheduled(game_data, delay) -> Optional["Game"]:
+    def from_scheduled(game_data, delay, api_refresh_rate) -> Optional["Game"]:
         game = Game(
             game_data["game_id"],
             game_data["game_date"],
             game_data.get("national_broadcasts") or [],
             game_data.get("series_status") or "",
             delay,
+            api_refresh_rate,
         )
         if game.update(True) == UpdateStatus.SUCCESS:
             return game
         return None
 
-    def __init__(self, game_id, date, broadcasts, series_status, delay_in_10s_of_seconds):
+    def __init__(self, game_id, date, broadcasts, series_status, delay_in_10s_of_seconds, api_refresh_rate):
         self.game_id = game_id
         self.date = date
         self.starttime = time.time()
@@ -46,6 +47,7 @@ class Game:
         self._current_data = {}
         self._broadcasts = broadcasts
         self._series_status = series_status
+        self._api_refresh_rate = api_refresh_rate
         self._status = {}
         self._uniform_data = Uniforms(game_id)
 
@@ -85,7 +87,7 @@ class Game:
         return datetime.fromisoformat(time.replace("Z", "+00:00"))
 
     def current_delay(self):
-        return (len(self._data_wait_queue) - 1) * GAME_UPDATE_RATE
+        return (len(self._data_wait_queue) - 1) * self._api_refresh_rate
 
     def home_name(self):
         return teams.TEAM_ID_NAME.get(
@@ -341,7 +343,7 @@ class Game:
     def __should_update(self):
         endtime = time.time()
         time_delta = endtime - self.starttime
-        return time_delta >= GAME_UPDATE_RATE
+        return time_delta >= self._api_refresh_rate
 
     @staticmethod
     def _format_id(player):

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -94,7 +94,7 @@ class Schedule:
             game_index = self._game_index_for_preferred_team()
             if game_index >= 0:  # we return -1 if no live games for preferred team
                 scheduled_game = self._games[game_index]
-                preferred_game = Game.from_scheduled(scheduled_game, self.config.delay_in_10s_of_seconds)
+                preferred_game = Game.from_scheduled(scheduled_game, self.config.delay_in_10s_of_seconds, self.config.api_refresh_rate)
                 if preferred_game is not None:
                     debug.log(
                         "Preferred Team's Game Status: %s, %s %d",
@@ -139,7 +139,7 @@ class Schedule:
     def __current_game(self):
         if self._games:
             scheduled_game = self._games[self.current_idx]
-            return Game.from_scheduled(scheduled_game, self.config.delay_in_10s_of_seconds)
+            return Game.from_scheduled(scheduled_game, self.config.delay_in_10s_of_seconds, self.config.api_refresh_rate)
         return None
 
     @staticmethod

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -23,7 +23,7 @@ class TestGame(unittest.TestCase):
     }
 
     def test_game(self):
-        game = data.game.Game.from_scheduled(self.game_data, delay=0)
+        game = data.game.Game.from_scheduled(self.game_data, delay=0, api_refresh_rate=10)
         self.assertIsNotNone(game)
         self.assertEqual(game.home_name(), "Nationals")
         self.assertEqual(game.home_abbreviation(), "WSH")
@@ -58,7 +58,7 @@ class TestGame(unittest.TestCase):
     def test_game_in_middle(self):
         # uses some timestamps to test specific points in the game and our delay logic
 
-        game = data.game.Game.from_scheduled(self.game_data, delay=1)
+        game = data.game.Game.from_scheduled(self.game_data, delay=1, api_refresh_rate=10)
         self.assertIsNotNone(game)
         self.assertEqual(game.current_delay(), 0)
 
@@ -98,7 +98,7 @@ class TestGame(unittest.TestCase):
             "game_id": 746423,
             "game_date": "2024-09-13",
             }
-        game = data.game.Game.from_scheduled(game_data, delay=0)
+        game = data.game.Game.from_scheduled(game_data, delay=0, api_refresh_rate=10)
         self.assertIsNotNone(game)
         # DET was wearing city connects
         self.assertEqual(game.home_special_uniforms(), data.uniforms.CITY_CONNECT)
@@ -136,7 +136,7 @@ class TestGame(unittest.TestCase):
             'game_id': 745808,
             'game_date': "2024-06-26",
         }
-        game = data.game.Game.from_scheduled(game_data, delay=0)
+        game = data.game.Game.from_scheduled(game_data, delay=0, api_refresh_rate=10)
         self.assertIsNotNone(game)
         self.assertEqual(game.update(force=True, testing_params={"timecode": "20240627_004712"}), UpdateStatus.SUCCESS)
 


### PR DESCRIPTION
Made the API refresh rate configurable in config.json in number of seconds. Defaults remains 10, it validates INT and wont allow less than 3 seconds so we don't spam the API.


