### PR TITLE
Re-add test migrations

### DIFF
--- a/colors/scoreboard.example.json
+++ b/colors/scoreboard.example.json
@@ -307,5 +307,7 @@
       "g": 14,
       "b": 25
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/colors/teams.example.json
+++ b/colors/teams.example.json
@@ -1035,5 +1035,7 @@
       "g": 255,
       "b": 255
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/config.example.json
+++ b/config.example.json
@@ -54,5 +54,15 @@
   "pregame_weather": true,
   "scrolling_speed": 2,
   "debug": false,
-  "demo_date": false
+  "demo_date": false,
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!",
+  "path": {
+    "to": {
+      "the": {
+        "renamed_key2": 1
+      }
+    }
+  },
+  "test_transaction": true
 }

--- a/coordinates/w128h32.example.json
+++ b/coordinates/w128h32.example.json
@@ -382,5 +382,7 @@
       "x": 125,
       "y": 31
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/coordinates/w128h64.example.json
+++ b/coordinates/w128h64.example.json
@@ -363,5 +363,7 @@
       "x": 125,
       "y": 63
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/coordinates/w192h64.example.json
+++ b/coordinates/w192h64.example.json
@@ -363,5 +363,7 @@
       "x": 125,
       "y": 63
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/coordinates/w32h32.example.json
+++ b/coordinates/w32h32.example.json
@@ -367,5 +367,7 @@
       "x": 29,
       "y": 31
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/coordinates/w64h32.example.json
+++ b/coordinates/w64h32.example.json
@@ -353,5 +353,7 @@
       "x": 61,
       "y": 31
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/coordinates/w64h64.example.json
+++ b/coordinates/w64h64.example.json
@@ -338,5 +338,7 @@
       "x": 61,
       "y": 63
     }
-  }
+  },
+  "new_key": "Hello world!",
+  "helloworld2": "Hello world!"
 }

--- a/migrations/1754370767_HelloWorld.py
+++ b/migrations/1754370767_HelloWorld.py
@@ -1,0 +1,28 @@
+from migrations import ConfigMigration
+
+import json
+
+
+class HelloWorld(ConfigMigration):
+    def up(self):
+        for _config_type, config_files in self.configs.items():
+            for config_file in config_files:
+                with open(config_file, 'r') as f:
+                    content = json.load(f)
+
+                content["new_key"] = "Hello world!"
+
+                with open(config_file, 'w') as f:
+                    json.dump(content, f, indent=2)
+
+    def down(self):
+        for _config_type, config_files in self.configs.items():
+            for config_file in config_files:
+                with open(config_file, 'r') as f:
+                    content = json.load(f)
+
+                if "new_key" in content:
+                    del content["new_key"]
+
+                with open(config_file, 'w') as f:
+                    json.dump(content, f, indent=2)

--- a/migrations/1754457017_HelloWorldTwo.py
+++ b/migrations/1754457017_HelloWorldTwo.py
@@ -1,0 +1,28 @@
+from migrations import ConfigMigration
+
+import json
+
+
+class HelloWorldTwo(ConfigMigration):
+    def up(self):
+        for _config_type, config_files in self.configs.items():
+            for config_file in config_files:
+                with open(config_file, 'r') as f:
+                    content = json.load(f)
+
+                content["helloworld2"] = "Hello world!"
+
+                with open(config_file, 'w') as f:
+                    json.dump(content, f, indent=2)
+
+    def down(self):
+        for _config_type, config_files in self.configs.items():
+            for config_file in config_files:
+                with open(config_file, 'r') as f:
+                    content = json.load(f)
+
+                if "helloworld2" in content:
+                    del content["helloworld2"]
+
+                with open(config_file, 'w') as f:
+                    json.dump(content, f, indent=2)

--- a/migrations/1754457591_KeypathTest.py
+++ b/migrations/1754457591_KeypathTest.py
@@ -1,0 +1,9 @@
+from migrations import ConfigMigration
+
+
+class KeypathTest(ConfigMigration):
+    def up(self):
+        self.add_key("path.to.the.key", 1, self.configs["base"])
+
+    def down(self):
+        self.remove_key("path", self.configs["base"])

--- a/migrations/1754459224_KeypathMoveTest.py
+++ b/migrations/1754459224_KeypathMoveTest.py
@@ -1,0 +1,9 @@
+from migrations import ConfigMigration
+
+
+class KeypathMoveTest(ConfigMigration):
+    def up(self):
+        self.move_key("path.to.the.key", "path.to.the.renamed_key", self.configs["base"])
+
+    def down(self):
+        self.move_key("path.to.the.renamed_key", "path.to.the.key", self.configs["base"])

--- a/migrations/1754460562_KeypathRenameTest.py
+++ b/migrations/1754460562_KeypathRenameTest.py
@@ -1,0 +1,9 @@
+from migrations import ConfigMigration
+
+
+class KeypathRenameTest(ConfigMigration):
+    def up(self):
+        self.rename_key("path.to.the.renamed_key", "renamed_key2", self.configs["base"])
+
+    def down(self):
+        self.rename_key("path.to.the.renamed_key2", "renamed_key", self.configs["base"])

--- a/migrations/1754537880_TestTransaction.py
+++ b/migrations/1754537880_TestTransaction.py
@@ -1,0 +1,26 @@
+from migrations import ConfigMigration, Transaction
+
+import json
+
+
+class TestTransaction(ConfigMigration):
+    def up(self):
+        with Transaction() as transaction:
+            for file in self.configs["base"]:
+                with open(file, 'r') as f:
+                    content = json.load(f)
+
+                content["test_transaction"] = True
+
+                transaction.write(file, content)
+
+    def down(self):
+        with Transaction() as transaction:
+            for file in self.configs["base"]:
+                with open(file, 'r') as f:
+                    content = json.load(f)
+
+                if "test_transaction" in content:
+                    del content["test_transaction"]
+
+                transaction.write(file, content)

--- a/migrations/1754540446_Empty.py
+++ b/migrations/1754540446_Empty.py
@@ -1,0 +1,9 @@
+from migrations import ConfigMigration
+
+
+class Empty(ConfigMigration):
+    def up(self):
+        pass
+
+    def down(self):
+        pass


### PR DESCRIPTION
Adds in some dummy migrations and runs them

```
PS C:\Users\tyler\code\mlb-led-scoreboard> python -m migrations up
Executing migrations...
================================================================================
MIGRATE 1754370767 << HelloWorld >>
================================================================================
MIGRATE 1754457017 << HelloWorldTwo >>
================================================================================
MIGRATE 1754457591 << KeypathTest >>
        BEGIN TRANSACTION
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.example.json
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.json
        COMMIT TRANSACTION
================================================================================
MIGRATE 1754459224 << KeypathMoveTest >>
        BEGIN TRANSACTION
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.example.json
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.json
        COMMIT TRANSACTION
================================================================================
MIGRATE 1754460562 << KeypathRenameTest >>
        BEGIN TRANSACTION
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.example.json
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.json
        COMMIT TRANSACTION
================================================================================
MIGRATE 1754537880 << TestTransaction >>
        BEGIN TRANSACTION
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.example.json
                STAGING: C:\Users\tyler\code\mlb-led-scoreboard\config.json
        COMMIT TRANSACTION
================================================================================
MIGRATE 1754540446 << Empty >>
================================================================================
Done.
```