### PR TITLE
Bump pyowm to 3.5.0 to resolve pkg_resources build-time deprecation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 feedparser>=6.0.11
 MLB_StatsAPI>=1.9.0
 Pillow>=10.0.1
-pyowm==3.3.0
+pyowm==3.5.0
 RGBMatrixEmulator>=0.13.5
 setuptools; python_version >= "3.12"
 tzlocal==4.2


### PR DESCRIPTION
Will need to test this but saw this deprecation in the build logs.

pyowm 3.5.0 resolves this
https://github.com/csparpa/pyowm/releases/tag/3.5.0