### PR TITLE
Add Raspberry Pi 5 Support

### DIFF
--- a/README-PI5.md
+++ b/README-PI5.md
@@ -12,10 +12,12 @@ This fork adds support for Raspberry Pi 5 using the Adafruit PioMatter library a
 
 ### For Raspberry Pi 5:
 - Raspberry Pi 5 (4GB or 8GB recommended)
-- Adafruit RGB Matrix Bonnet or HAT
+- RGB Matrix HAT/Adapter (Seekgreat Rev 3.8, Adafruit RGB Matrix Bonnet/HAT, or compatible)
 - HUB75 RGB LED Matrix Panel (tested with 64x32)
 - 5V Power Supply (4-5A per panel)
 - MicroSD card (16GB+ recommended)
+
+**Note:** This fork has been tested and confirmed working with the Seekgreat RGB Matrix Adapter Board Rev 3.8.
 
 ### For Raspberry Pi 4 and Earlier:
 - Same as original project (see main README.md)
@@ -59,6 +61,10 @@ sudo udevadm trigger
 ### On Raspberry Pi 5:
 
 ```bash
+# Default (uses Active3 pinout for Seekgreat and similar boards)
+sudo python3 main.py --pi5 --led-rows=32 --led-cols=64
+
+# For Adafruit HAT/Bonnet, specify the hardware mapping:
 sudo python3 main.py --pi5 --led-rows=32 --led-cols=64 --led-gpio-mapping=adafruit-hat
 ```
 
@@ -70,7 +76,25 @@ sudo python3 main.py --led-rows=32 --led-cols=64 --led-gpio-mapping=adafruit-hat
 
 ## Configuration
 
-The `--pi5` flag tells the software to use the PioMatter driver instead of the hzeller driver. All other configuration options remain the same.
+The `--pi5` flag tells the software to use the PioMatter driver instead of the hzeller driver.
+
+### Hardware Pinout Mapping:
+
+The default pinout is `active3` which works with:
+- Seekgreat RGB Matrix Adapter Board Rev 3.8
+- Most generic RGB Matrix HATs
+
+For Adafruit boards, use:
+```bash
+--led-gpio-mapping=adafruit-hat     # For Adafruit Matrix HAT
+--led-gpio-mapping=adafruit-bonnet  # For Adafruit Matrix Bonnet
+```
+
+**Testing Your Board:** If you're unsure which pinout to use, run:
+```bash
+sudo python3 test_pinouts.py
+```
+This will cycle through all available pinouts and flash colors to help you identify the correct one.
 
 ### Common Options:
 

--- a/README-PI5.md
+++ b/README-PI5.md
@@ -1,0 +1,167 @@
+# Raspberry Pi 5 Support for MLB LED Scoreboard
+
+This fork adds support for Raspberry Pi 5 using the Adafruit PioMatter library alongside the existing hzeller driver for Pi 4 and earlier.
+
+## What's New
+
+- **Dual Driver Support**: Works with both Raspberry Pi 4 (hzeller) and Pi 5 (PioMatter)
+- **Automatic Detection**: Use `--pi5` flag to enable Pi 5 mode
+- **Abstraction Layer**: Clean driver interface that can support future hardware
+
+## Hardware Requirements
+
+### For Raspberry Pi 5:
+- Raspberry Pi 5 (4GB or 8GB recommended)
+- Adafruit RGB Matrix Bonnet or HAT
+- HUB75 RGB LED Matrix Panel (tested with 64x32)
+- 5V Power Supply (4-5A per panel)
+- MicroSD card (16GB+ recommended)
+
+### For Raspberry Pi 4 and Earlier:
+- Same as original project (see main README.md)
+
+## Installation
+
+### 1. Basic Setup (Same for all Pi versions)
+
+```bash
+# Clone this repository
+git clone https://github.com/YOUR_USERNAME/mlb-led-scoreboard.git
+cd mlb-led-scoreboard
+
+# Run the base installation
+sudo ./install.sh
+```
+
+### 2. Raspberry Pi 5 Specific Setup
+
+If you're using a Raspberry Pi 5, install the additional dependencies:
+
+```bash
+# Install Pi 5 dependencies
+pip3 install -r requirements-pi5.txt
+
+# Verify PIO device access
+ls -l /dev/pio0
+
+# If pio0 doesn't exist, update your firmware
+sudo apt update && sudo apt upgrade -y
+sudo reboot
+
+# If pio0 exists but has wrong permissions, add udev rule:
+echo 'SUBSYSTEM=="*-pio", GROUP="gpio", MODE="0660"' | sudo tee /etc/udev/rules.d/99-pio.rules
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+## Running the Scoreboard
+
+### On Raspberry Pi 5:
+
+```bash
+sudo python3 main.py --pi5 --led-rows=32 --led-cols=64 --led-gpio-mapping=adafruit-hat
+```
+
+### On Raspberry Pi 4 and Earlier:
+
+```bash
+sudo python3 main.py --led-rows=32 --led-cols=64 --led-gpio-mapping=adafruit-hat
+```
+
+## Configuration
+
+The `--pi5` flag tells the software to use the PioMatter driver instead of the hzeller driver. All other configuration options remain the same.
+
+### Common Options:
+
+```bash
+--led-rows=32          # Height of your panel (16 or 32)
+--led-cols=64          # Width of your panel (32 or 64)
+--led-chain=2          # Number of panels chained together
+--led-brightness=75    # Brightness level (1-100)
+--led-gpio-mapping=adafruit-hat  # Hardware mapping
+```
+
+## Differences Between Pi 4 and Pi 5 Drivers
+
+| Feature | Pi 4 (hzeller) | Pi 5 (PioMatter) |
+|---------|----------------|------------------|
+| Library | rpi-rgb-led-matrix | Adafruit Blinka PioMatter |
+| Performance | Excellent | Good (newer, still optimizing) |
+| Text Rendering | BDF fonts | PIL/TrueType fonts |
+| Hardware | Direct GPIO | RP1 PIO subsystem |
+
+## Troubleshooting
+
+### Pi 5 Issues:
+
+**Matrix doesn't light up:**
+- Check that `/dev/pio0` exists
+- Verify power supply is adequate
+- Check wiring matches Adafruit guide
+- Try running with `sudo`
+
+**Permission denied on /dev/pio0:**
+```bash
+sudo usermod -a -G gpio $USER
+# Then log out and back in
+```
+
+**Import error for piomatter:**
+```bash
+pip3 install --upgrade Adafruit-Blinka-Raspberry-Pi5-Piomatter
+```
+
+**Text positioning looks wrong:**
+- Pi 5 uses PIL for rendering which has different baseline behavior
+- You may need to adjust y-coordinates in custom renderers
+
+### Pi 4 Issues:
+
+See the main README.md for Pi 4 troubleshooting.
+
+## Development
+
+### Architecture
+
+The driver abstraction is in `driver/`:
+- `base.py` - Abstract base classes for drivers
+- `hzeller_adapter.py` - Wrapper for Pi 4 (rgbmatrix)
+- `piomatter_adapter.py` - Wrapper for Pi 5 (PioMatter)
+- `__init__.py` - Driver factory and mode selection
+
+### Adding Support for New Hardware
+
+1. Create a new adapter in `driver/your_adapter.py`
+2. Implement `MatrixDriverBase` and `GraphicsBase`
+3. Add a new `DriverMode` in `driver/mode.py`
+4. Update `driver/__init__.py` to detect and load your driver
+
+## Known Limitations
+
+### Pi 5:
+- BDF font support is limited (uses PIL fonts as fallback)
+- Some hzeller-specific features may not be available
+- Performance may be slightly lower than Pi 4
+
+### Both:
+- Both drivers cannot be used simultaneously (would require different hardware setups)
+
+## Credits
+
+- Original MLB LED Scoreboard: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard
+- hzeller rpi-rgb-led-matrix: https://github.com/hzeller/rpi-rgb-led-matrix
+- Adafruit PioMatter: https://github.com/adafruit/Adafruit_Blinka_Raspberry_Pi5_Piomatter
+
+## License
+
+Same as original project - see LICENSE.md
+
+## Contributing
+
+Contributions welcome! Please test on both Pi 4 and Pi 5 if possible.
+
+1. Fork the repo
+2. Create a feature branch
+3. Test your changes
+4. Submit a pull request

--- a/driver/__init__.py
+++ b/driver/__init__.py
@@ -127,7 +127,7 @@ def _create_pi5_options_class():
             self.cols = 64
             self.chain_length = 1
             self.parallel = 1
-            self.hardware_mapping = 'active3'  # Default for Seekgreat and similar boards
+            self.hardware_mapping = 'active3-bgr'  # Default for Seekgreat boards (BGR color order)
             self.gpio_slowdown = 4
             self.brightness = 100
             self.pwm_bits = 11

--- a/driver/__init__.py
+++ b/driver/__init__.py
@@ -113,7 +113,7 @@ class DriverWrapper:
                 return self._graphics_adapter
         
         # Default: pass through to driver
-        if hasattr(self, 'driver'):
+        if 'driver' in self.__dict__:
             return getattr(self.driver, name)
         
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")

--- a/driver/__init__.py
+++ b/driver/__init__.py
@@ -127,7 +127,7 @@ def _create_pi5_options_class():
             self.cols = 64
             self.chain_length = 1
             self.parallel = 1
-            self.hardware_mapping = 'adafruit-hat'
+            self.hardware_mapping = 'active3'  # Default for Seekgreat and similar boards
             self.gpio_slowdown = 4
             self.brightness = 100
             self.pwm_bits = 11

--- a/driver/__init__.py
+++ b/driver/__init__.py
@@ -10,7 +10,11 @@ class DriverWrapper:
 
         if 'unittest' in sys.modules or args().emulated:
             self.set_mode(DriverMode.SOFTWARE_EMULATION)
+        elif args().pi5:
+            # User explicitly requested Pi 5 mode
+            self.set_mode(DriverMode.HARDWARE_PI5)
         else:
+            # Default to Pi 4 / hzeller mode
             self.set_mode(DriverMode.HARDWARE)
 
 
@@ -19,32 +23,121 @@ class DriverWrapper:
         return 'driver'
 
     def is_hardware(self):
-        return self.mode == DriverMode.HARDWARE
+        return self.mode == DriverMode.HARDWARE or self.mode == DriverMode.HARDWARE_PI5
 
     def is_emulated(self):
         return self.mode == DriverMode.SOFTWARE_EMULATION
+    
+    def is_pi5(self):
+        return self.mode == DriverMode.HARDWARE_PI5
 
     def set_mode(self, mode):
         self.mode = mode
 
-        if self.is_hardware():
+        if self.mode == DriverMode.HARDWARE_PI5:
+            # Raspberry Pi 5 mode using PioMatter
             try:
-                import rgbmatrix
-
-                self.driver = rgbmatrix
-            except ImportError:
+                from driver.piomatter_adapter import (
+                    PioMatterMatrixAdapter,
+                    PioMatterGraphicsAdapter
+                )
+                
+                # Store the adapter classes
+                self._matrix_adapter = PioMatterMatrixAdapter
+                self._graphics_adapter = PioMatterGraphicsAdapter()
+                
+            except ImportError as e:
+                print(f"Failed to import PioMatter library: {e}")
+                print("Falling back to software emulation.")
                 import RGBMatrixEmulator
-
+                self.mode = DriverMode.SOFTWARE_EMULATION
+                self.driver = RGBMatrixEmulator
+                self.hardware_load_failed = True
+                
+        elif self.mode == DriverMode.HARDWARE:
+            # Raspberry Pi 4 and earlier using hzeller rgbmatrix
+            try:
+                from driver.hzeller_adapter import (
+                    HzellerMatrixAdapter,
+                    HzellerGraphicsAdapter
+                )
+                
+                # Store the adapter classes
+                self._matrix_adapter = HzellerMatrixAdapter
+                self._graphics_adapter = HzellerGraphicsAdapter()
+                
+            except ImportError:
+                # Fall back to RGBMatrixEmulator if rgbmatrix not available
+                import RGBMatrixEmulator
                 self.mode = DriverMode.SOFTWARE_EMULATION
                 self.driver = RGBMatrixEmulator
                 self.hardware_load_failed = True
         else:
+            # Software emulation mode
             import RGBMatrixEmulator
-
             self.driver = RGBMatrixEmulator
 
+    def RGBMatrix(self, options):
+        """Create an RGBMatrix instance using the appropriate adapter."""
+        if self.mode == DriverMode.HARDWARE_PI5 or self.mode == DriverMode.HARDWARE:
+            return self._matrix_adapter(options)
+        else:
+            # Emulator mode
+            return self.driver.RGBMatrix(options=options)
+    
+    @property
+    def graphics(self):
+        """Return the graphics adapter."""
+        if self.mode == DriverMode.HARDWARE_PI5 or self.mode == DriverMode.HARDWARE:
+            return self._graphics_adapter
+        else:
+            return self.driver.graphics
+
     def __getattr__(self, name):
-        return getattr(self.driver, name)
+        """
+        Proxy attribute access to the underlying driver.
+        For adapters, we need to handle special cases.
+        """
+        if self.mode == DriverMode.HARDWARE_PI5 or self.mode == DriverMode.HARDWARE:
+            # For adapter modes, check if it's a known attribute
+            if name == 'RGBMatrixOptions':
+                if self.mode == DriverMode.HARDWARE:
+                    import rgbmatrix
+                    return rgbmatrix.RGBMatrixOptions
+                else:
+                    # Pi 5 mode - create a simple options class
+                    return _create_pi5_options_class()
+            elif name == '__version__':
+                return 'adapter-1.0.0'
+            elif name == 'graphics':
+                return self._graphics_adapter
+        
+        # Default: pass through to driver
+        if hasattr(self, 'driver'):
+            return getattr(self.driver, name)
+        
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+
+
+def _create_pi5_options_class():
+    """Create a simple options class compatible with Pi 5."""
+    class RGBMatrixOptions:
+        def __init__(self):
+            self.rows = 32
+            self.cols = 64
+            self.chain_length = 1
+            self.parallel = 1
+            self.hardware_mapping = 'adafruit-hat'
+            self.gpio_slowdown = 4
+            self.brightness = 100
+            self.pwm_bits = 11
+            self.pwm_lsb_nanoseconds = 130
+            self.led_rgb_sequence = "RGB"
+            self.pixel_mapper_config = ""
+            self.panel_type = ""
+            self.multiplexing = 0
+            
+    return RGBMatrixOptions
 
 
 sys.modules['driver'] = DriverWrapper()

--- a/driver/base.py
+++ b/driver/base.py
@@ -1,0 +1,72 @@
+"""
+Base interface for matrix drivers.
+This defines the common interface that both hzeller and PioMatter adapters must implement.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+
+class MatrixDriverBase(ABC):
+    """Abstract base class for matrix drivers."""
+
+    @abstractmethod
+    def __init__(self, options):
+        """Initialize the matrix with the given options."""
+        pass
+
+    @property
+    @abstractmethod
+    def width(self) -> int:
+        """Get the width of the matrix."""
+        pass
+
+    @property
+    @abstractmethod
+    def height(self) -> int:
+        """Get the height of the matrix."""
+        pass
+
+    @abstractmethod
+    def CreateFrameCanvas(self):
+        """Create a new frame canvas for double-buffering."""
+        pass
+
+    @abstractmethod
+    def SwapOnVSync(self, canvas):
+        """Swap the given canvas with the displayed canvas."""
+        pass
+
+    @abstractmethod
+    def SetImage(self, image, offset_x=0, offset_y=0):
+        """Set an image on the matrix."""
+        pass
+
+    @abstractmethod
+    def Clear(self):
+        """Clear the matrix."""
+        pass
+
+
+class GraphicsBase(ABC):
+    """Abstract base class for graphics operations."""
+
+    @abstractmethod
+    def DrawText(self, canvas, font, x, y, color, text):
+        """Draw text on the canvas."""
+        pass
+
+    @abstractmethod
+    def DrawLine(self, canvas, x1, y1, x2, y2, color):
+        """Draw a line on the canvas."""
+        pass
+
+    @abstractmethod
+    def Color(self, r, g, b):
+        """Create a color object."""
+        pass
+
+    @abstractmethod
+    def Font(self):
+        """Create a font object."""
+        pass

--- a/driver/hzeller_adapter.py
+++ b/driver/hzeller_adapter.py
@@ -1,0 +1,57 @@
+"""
+Adapter for the hzeller rpi-rgb-led-matrix library.
+This wraps the existing rgbmatrix library to conform to our base interface.
+Compatible with Raspberry Pi 4 and earlier.
+"""
+
+from driver.base import MatrixDriverBase, GraphicsBase
+
+
+class HzellerMatrixAdapter(MatrixDriverBase):
+    """Adapter for the hzeller rgbmatrix library."""
+
+    def __init__(self, options):
+        """Initialize using the rgbmatrix library."""
+        import rgbmatrix
+        self._matrix = rgbmatrix.RGBMatrix(options=options)
+        self._rgbmatrix = rgbmatrix
+
+    @property
+    def width(self):
+        return self._matrix.width
+
+    @property
+    def height(self):
+        return self._matrix.height
+
+    def CreateFrameCanvas(self):
+        return self._matrix.CreateFrameCanvas()
+
+    def SwapOnVSync(self, canvas):
+        return self._matrix.SwapOnVSync(canvas)
+
+    def SetImage(self, image, offset_x=0, offset_y=0):
+        return self._matrix.SetImage(image, offset_x, offset_y)
+
+    def Clear(self):
+        return self._matrix.Clear()
+
+
+class HzellerGraphicsAdapter(GraphicsBase):
+    """Adapter for hzeller graphics module."""
+
+    def __init__(self):
+        from rgbmatrix import graphics
+        self._graphics = graphics
+
+    def DrawText(self, canvas, font, x, y, color, text):
+        return self._graphics.DrawText(canvas, font, x, y, color, text)
+
+    def DrawLine(self, canvas, x1, y1, x2, y2, color):
+        return self._graphics.DrawLine(canvas, x1, y1, x2, y2, color)
+
+    def Color(self, r, g, b):
+        return self._graphics.Color(r, g, b)
+
+    def Font(self):
+        return self._graphics.Font()

--- a/driver/mode.py
+++ b/driver/mode.py
@@ -2,5 +2,6 @@ from enum import Enum
 
 
 class DriverMode(Enum):
-    HARDWARE           = 0
-    SOFTWARE_EMULATION = 1
+    HARDWARE           = 0  # Raspberry Pi 4 and earlier (hzeller)
+    HARDWARE_PI5       = 1  # Raspberry Pi 5 (PioMatter)
+    SOFTWARE_EMULATION = 2

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -185,18 +185,18 @@ class PioMatterFont:
         except Exception:
             pass
         
-        # Fallback to tom-thumb.bdf
+        # Fallback to 4x6.bdf
         try:
             from PIL import ImageFont
             import os
             fallback_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 
-                                         'assets', 'fonts', 'patched', 'tom-thumb.bdf')
+                                         'assets', 'fonts', 'patched', '4x6.bdf')
             self._font = ImageFont.load(fallback_path)
             return True
         except Exception:
             pass
         
-        # Ultimate fallback to PIL default if tom-thumb not found
+        # Ultimate fallback to PIL default if 4x6 not found
         try:
             from PIL import ImageFont
             self._font = ImageFont.load_default()

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -270,14 +270,22 @@ class PioMatterGraphicsAdapter(GraphicsBase):
                     for char in text:
                         try:
                             glyph = font._font.glyph(char)
+                            # Get glyph properties
+                            bbx = glyph.meta.get('BBX', [glyph.width, glyph.height, 0, 0])
+                            offset_x = bbx[2] if len(bbx) > 2 else 0
+                            offset_y = bbx[3] if len(bbx) > 3 else 0
+                            
                             # Draw glyph bitmap
-                            for dy in range(glyph.height):
-                                for dx in range(glyph.width):
-                                    if glyph.bitmap[dy][dx]:
-                                        canvas._draw.point((current_x + dx, y + dy), fill=pil_color)
+                            for row_idx, row in enumerate(glyph.bitmap):
+                                for col_idx, pixel in enumerate(row):
+                                    if pixel:
+                                        px = current_x + offset_x + col_idx
+                                        py = y - offset_y - (glyph.height - row_idx - 1)
+                                        canvas._draw.point((px, py), fill=pil_color)
                             current_x += glyph.advance_width
-                        except Exception:
+                        except Exception as e:
                             # Character not found, skip it
+                            print(f"Warning: Could not render char '{char}': {e}")
                             current_x += 4  # Default spacing
                     return current_x - x  # Return width
                 else:

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -49,19 +49,22 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         # Initialize PioMatter (chain/parallel handled by geometry)
         
         # Determine pinout based on --led-gpio-mapping option
-        # Default to Active3 for Seekgreat and similar boards
+        # Default to Active3BGR for Seekgreat boards (colors are BGR order)
         pinout_map = {
             'adafruit-hat': piomatter.Pinout.AdafruitMatrixHat,
             'adafruit-hat-pwm': piomatter.Pinout.AdafruitMatrixHat,
+            'adafruit-hat-bgr': piomatter.Pinout.AdafruitMatrixHatBGR,
             'adafruit-bonnet': piomatter.Pinout.AdafruitMatrixBonnet,
-            'regular': piomatter.Pinout.Active3,
-            'classic': piomatter.Pinout.Active3,
+            'adafruit-bonnet-bgr': piomatter.Pinout.AdafruitMatrixBonnetBGR,
+            'regular': piomatter.Pinout.Active3BGR,
+            'classic': piomatter.Pinout.Active3BGR,
             'active3': piomatter.Pinout.Active3,
+            'active3-bgr': piomatter.Pinout.Active3BGR,
         }
         
-        # Get the mapping from options if available, default to Active3
-        hardware_mapping = getattr(options, 'hardware_mapping', 'active3').lower()
-        pinout = pinout_map.get(hardware_mapping, piomatter.Pinout.Active3)
+        # Get the mapping from options if available, default to Active3BGR
+        hardware_mapping = getattr(options, 'hardware_mapping', 'active3-bgr').lower()
+        pinout = pinout_map.get(hardware_mapping, piomatter.Pinout.Active3BGR)
         
         self._matrix = piomatter.PioMatter(
             colorspace=piomatter.Colorspace.RGB888Packed,

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -19,15 +19,15 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         width = options.cols * options.chain_length
         height = options.rows * options.parallel
 
-        # Determine number of address lines based on panel rows (not total rows)
-        # Each individual panel's rows, not the total display
-        # Common configurations: 16 rows = 4 addr lines, 32 rows = 5 addr lines, 64 rows = 6 addr lines
+        # Determine number of address lines based on panel rows
+        # 64x32 panels typically use 1/16 scan = 4 address lines
+        # 64x64 panels typically use 1/32 scan = 5 address lines
         panel_rows = options.rows  # Single panel height
         n_addr_lines = {
-            16: 4,
-            32: 5,
-            64: 6
-        }.get(panel_rows, 5)  # Default to 5 for 32-row panels
+            16: 4,   # 1/16 scan
+            32: 4,   # 1/16 scan (most common for 64x32 panels)
+            64: 5    # 1/32 scan
+        }.get(panel_rows, 4)  # Default to 4 address lines
 
         # Create geometry - PioMatter expects dimensions of a SINGLE panel
         # The library handles chaining and parallel internally

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -112,6 +112,10 @@ class PioMatterCanvas:
         """Clear the canvas."""
         self._image.paste(Image.new('RGB', (self.width, self.height), (0, 0, 0)))
 
+    def Fill(self, r, g, b):
+        """Fill the entire canvas with a color."""
+        self._image.paste(Image.new('RGB', (self.width, self.height), (r, g, b)))
+
     def SetPixel(self, x, y, r, g, b):
         """Set a single pixel."""
         self._draw.point((x, y), fill=(r, g, b))

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -289,11 +289,8 @@ class PioMatterGraphicsAdapter(GraphicsBase):
                                         canvas._draw.point((px, py), fill=pil_color)
                             current_x += dwx0
                         except Exception as e:
-                            # Character not found, skip it
-                            print(f"Warning: Could not render char '{char}': {e}")
-                            import traceback
-                            traceback.print_exc()
-                            current_x += 4  # Default spacing
+                            # Character not found, skip with default spacing
+                            current_x += 4
                     return current_x - x  # Return width
                 else:
                     # Use PIL font rendering

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -177,22 +177,32 @@ class PioMatterFont:
         # Store the path for reference
         self._font_path = path
 
-        # Try to find a similar TrueType font
-        # For now, use a default PIL font
-        # Users may need to install specific fonts
+        # Try to load the requested BDF font first
         try:
-            # Try to load as BDF (PIL supports BDF)
             from PIL import ImageFont
             self._font = ImageFont.load(path)
+            return True
         except Exception:
-            # Fall back to default font
-            try:
-                # Try DejaVu Sans Mono which is commonly available
-                self._font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 10)
-            except Exception:
-                # Ultimate fallback to default
-                self._font = ImageFont.load_default()
-
+            pass
+        
+        # Fallback to tom-thumb.bdf
+        try:
+            from PIL import ImageFont
+            import os
+            fallback_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 
+                                         'assets', 'fonts', 'patched', 'tom-thumb.bdf')
+            self._font = ImageFont.load(fallback_path)
+            return True
+        except Exception:
+            pass
+        
+        # Ultimate fallback to PIL default if tom-thumb not found
+        try:
+            from PIL import ImageFont
+            self._font = ImageFont.load_default()
+        except Exception:
+            self._font = None
+        
         return True
 
     def CharacterWidth(self, char):

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -22,13 +22,12 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         # Determine number of address lines based on panel rows
         # 64x32 panels typically use 1/16 scan = 4 address lines
         # 64x64 panels typically use 1/32 scan = 5 address lines
-        # Some boards (like Seekgreat) use 1-based addressing, requiring 5 lines for 32-row panels
         panel_rows = options.rows  # Single panel height
         n_addr_lines = {
             16: 4,   # 1/16 scan
-            32: 5,   # 1/32 scan (for boards with 1-based addressing like Seekgreat)
-            64: 6    # 1/64 scan
-        }.get(panel_rows, 5)  # Default to 5 address lines
+            32: 4,   # 1/16 scan (most common for 64x32 panels)
+            64: 5    # 1/32 scan
+        }.get(panel_rows, 4)  # Default to 4 address lines
 
         # Create geometry - use total display dimensions
         # For a single 64x32 panel: width=64, height=32

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -174,44 +174,49 @@ class PioMatterFont:
 
     def LoadFont(self, path):
         """Load a BDF font. Convert to PIL font."""
-        from PIL import ImageFont
+        from PIL import ImageFont, BdfFontFile
         import os
         
         # Store the path for reference
         self._font_path = path
 
-        # Try to load the requested BDF font first
+        # Try to load BDF font using BdfFontFile (for standalone BDF files)
         try:
-            self._font = ImageFont.load(path)
-            return True
+            with open(path, 'rb') as f:
+                bdf_font = BdfFontFile.BdfFontFile(f)
+                self._font = bdf_font
+                print(f"Successfully loaded BDF font: {path}")
+                return True
         except Exception as e:
-            print(f"Failed to load font {path}: {e}")
+            print(f"Failed to load BDF font {path}: {e}")
         
         # Fallback to 4x6.bdf
         try:
             fallback_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 
                                          'assets', 'fonts', 'patched', '4x6.bdf')
-            self._font = ImageFont.load(fallback_path)
-            print(f"Using fallback font: {fallback_path}")
-            return True
+            with open(fallback_path, 'rb') as f:
+                bdf_font = BdfFontFile.BdfFontFile(f)
+                self._font = bdf_font
+                print(f"Successfully loaded fallback BDF: {fallback_path}")
+                return True
         except Exception as e:
             print(f"Failed to load 4x6.bdf: {e}")
         
-        # Try loading a very small TrueType font (4 point size to approximate 4x6 pixels)
+        # Try loading a very small TrueType font (4-5 point size to approximate 4x6 pixels)
         try:
-            # Try common monospace fonts at 4pt to get approximately 4x6 pixels
+            # Try common monospace fonts at small size
             for ttf_path in [
                 "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
                 "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
             ]:
                 if os.path.exists(ttf_path):
-                    self._font = ImageFont.truetype(ttf_path, size=6)  # 6pt font
-                    print(f"Using TrueType fallback at 6pt: {ttf_path}")
+                    self._font = ImageFont.truetype(ttf_path, size=5)  # 5pt font for smaller size
+                    print(f"Using TrueType fallback at 5pt: {ttf_path}")
                     return True
         except Exception as e:
             print(f"Failed to load TrueType font: {e}")
         
-        # Ultimate fallback - create a minimal default
+        # Ultimate fallback - PIL default
         try:
             self._font = ImageFont.load_default()
             print("Using PIL default font")

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -32,27 +32,33 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         # Create geometry - use total display dimensions
         # For a single 64x32 panel: width=64, height=32
         # PioMatter's geometry describes the overall display configuration
+        print(f"DEBUG: Creating geometry - width={width}, height={height}, n_addr_lines={n_addr_lines}")
         self._geometry = piomatter.Geometry(
             width=width,  # Total width (cols * chain)
             height=height,  # Total height (rows * parallel)
             n_addr_lines=n_addr_lines,
             rotation=piomatter.Orientation.Normal
         )
+        print("DEBUG: Geometry created successfully")
 
         # Create PIL canvas
+        print("DEBUG: Creating PIL canvas")
         self._canvas = Image.new('RGB', (width, height), (0, 0, 0))
         self._draw = ImageDraw.Draw(self._canvas)
 
         # Create framebuffer
+        print("DEBUG: Creating framebuffer")
         self._framebuffer = np.asarray(self._canvas).copy()
 
         # Initialize PioMatter (chain/parallel handled by geometry)
+        print("DEBUG: Initializing PioMatter display")
         self._matrix = piomatter.PioMatter(
             colorspace=piomatter.Colorspace.RGB888Packed,
             pinout=piomatter.Pinout.AdafruitMatrixBonnet,
             framebuffer=self._framebuffer,
             geometry=self._geometry
         )
+        print("DEBUG: PioMatter display initialized successfully")
 
         self._width = width
         self._height = height
@@ -74,12 +80,16 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
 
     def SwapOnVSync(self, canvas):
         """Swap buffers and update the display."""
+        print("DEBUG: SwapOnVSync called")
         if isinstance(canvas, PioMatterCanvas):
             try:
                 # Copy canvas content to framebuffer
+                print("DEBUG: Copying canvas to framebuffer")
                 self._framebuffer[:] = np.asarray(canvas._image)
                 # Update the display
+                print("DEBUG: Calling matrix.show()")
                 self._matrix.show()
+                print("DEBUG: matrix.show() completed")
             except Exception as e:
                 print(f"ERROR in SwapOnVSync: {e}")
                 import traceback
@@ -119,6 +129,7 @@ class PioMatterCanvas:
 
     def Fill(self, r, g, b):
         """Fill the entire canvas with a color."""
+        print(f"DEBUG: Fill called with RGB({r}, {g}, {b})")
         self._image.paste(Image.new('RGB', (self.width, self.height), (r, g, b)))
 
     def SetPixel(self, x, y, r, g, b):

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -1,0 +1,192 @@
+"""
+Adapter for the Adafruit PioMatter library for Raspberry Pi 5.
+This provides compatibility with the mlb-led-scoreboard using the new Pi 5 driver.
+"""
+
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+from driver.base import MatrixDriverBase, GraphicsBase
+
+
+class PioMatterMatrixAdapter(MatrixDriverBase):
+    """Adapter for the Adafruit PioMatter library (Raspberry Pi 5)."""
+
+    def __init__(self, options):
+        """Initialize using the PioMatter library."""
+        import adafruit_blinka_raspberry_pi5_piomatter as piomatter
+
+        # Extract dimensions from options
+        width = options.cols * options.chain_length
+        height = options.rows * options.parallel
+
+        # Determine number of address lines based on rows
+        # Common configurations: 16 rows = 4 addr lines, 32 rows = 5 addr lines
+        n_addr_lines = {
+            16: 4,
+            32: 5,
+            64: 6
+        }.get(options.rows, 4)
+
+        # Create geometry
+        self._geometry = piomatter.Geometry(
+            width=width,
+            height=height,
+            n_addr_lines=n_addr_lines,
+            rotation=piomatter.Orientation.Normal
+        )
+
+        # Create PIL canvas
+        self._canvas = Image.new('RGB', (width, height), (0, 0, 0))
+        self._draw = ImageDraw.Draw(self._canvas)
+
+        # Create framebuffer
+        self._framebuffer = np.asarray(self._canvas).copy()
+
+        # Initialize PioMatter
+        self._matrix = piomatter.PioMatter(
+            colorspace=piomatter.Colorspace.RGB888Packed,
+            pinout=piomatter.Pinout.AdafruitMatrixBonnet,
+            framebuffer=self._framebuffer,
+            geometry=self._geometry
+        )
+
+        self._width = width
+        self._height = height
+        self._double_buffer = None
+
+    @property
+    def width(self):
+        return self._width
+
+    @property
+    def height(self):
+        return self._height
+
+    def CreateFrameCanvas(self):
+        """Create a double-buffer canvas."""
+        if self._double_buffer is None:
+            self._double_buffer = PioMatterCanvas(self._width, self._height)
+        return self._double_buffer
+
+    def SwapOnVSync(self, canvas):
+        """Swap buffers and update the display."""
+        if isinstance(canvas, PioMatterCanvas):
+            # Copy canvas content to framebuffer
+            self._framebuffer[:] = np.asarray(canvas._image)
+            # Update the display
+            self._matrix.show()
+        return canvas
+
+    def SetImage(self, image, offset_x=0, offset_y=0):
+        """Display an image on the matrix."""
+        # Paste image onto canvas
+        self._canvas.paste(image, (offset_x, offset_y))
+        # Update framebuffer
+        self._framebuffer[:] = np.asarray(self._canvas)
+        # Show on display
+        self._matrix.show()
+
+    def Clear(self):
+        """Clear the display."""
+        self._canvas.paste(Image.new('RGB', (self._width, self._height), (0, 0, 0)))
+        self._framebuffer[:] = np.asarray(self._canvas)
+        self._matrix.show()
+
+
+class PioMatterCanvas:
+    """
+    Canvas object that mimics the hzeller canvas interface but uses PIL.
+    """
+
+    def __init__(self, width, height):
+        self._image = Image.new('RGB', (width, height), (0, 0, 0))
+        self._draw = ImageDraw.Draw(self._image)
+        self.width = width
+        self.height = height
+
+    def Clear(self):
+        """Clear the canvas."""
+        self._image.paste(Image.new('RGB', (self.width, self.height), (0, 0, 0)))
+
+    def SetPixel(self, x, y, r, g, b):
+        """Set a single pixel."""
+        self._draw.point((x, y), fill=(r, g, b))
+
+
+class PioMatterColor:
+    """Color object for PioMatter that mimics hzeller Color."""
+
+    def __init__(self, r, g, b):
+        self.r = r
+        self.g = g
+        self.b = b
+
+    def to_tuple(self):
+        return (self.r, self.g, self.b)
+
+
+class PioMatterFont:
+    """Font object for PioMatter that mimics hzeller Font."""
+
+    def __init__(self):
+        self._font = None
+        self._font_path = None
+
+    def LoadFont(self, path):
+        """Load a BDF font. Convert to PIL font."""
+        # Store the path for reference
+        self._font_path = path
+
+        # Try to find a similar TrueType font
+        # For now, use a default PIL font
+        # Users may need to install specific fonts
+        try:
+            # Try to load as BDF (PIL supports BDF)
+            from PIL import ImageFont
+            self._font = ImageFont.load(path)
+        except Exception:
+            # Fall back to default font
+            try:
+                # Try DejaVu Sans Mono which is commonly available
+                self._font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 10)
+            except Exception:
+                # Ultimate fallback to default
+                self._font = ImageFont.load_default()
+
+        return True
+
+    def CharacterWidth(self, char):
+        """Get character width."""
+        if self._font:
+            bbox = self._font.getbbox(char)
+            return bbox[2] - bbox[0]
+        return 6  # Default fallback
+
+
+class PioMatterGraphicsAdapter(GraphicsBase):
+    """Graphics adapter for PioMatter using PIL drawing."""
+
+    def __init__(self):
+        pass
+
+    def DrawText(self, canvas, font, x, y, color, text):
+        """Draw text using PIL."""
+        if isinstance(canvas, PioMatterCanvas):
+            pil_color = color.to_tuple() if isinstance(color, PioMatterColor) else color
+            # Note: PIL text baseline is different from hzeller, may need adjustment
+            canvas._draw.text((x, y - 10), text, fill=pil_color, font=font._font if hasattr(font, '_font') else None)
+            return len(text) * 6  # Approximate width
+
+    def DrawLine(self, canvas, x1, y1, x2, y2, color):
+        """Draw a line using PIL."""
+        if isinstance(canvas, PioMatterCanvas):
+            pil_color = color.to_tuple() if isinstance(color, PioMatterColor) else color
+            canvas._draw.line([(x1, y1), (x2, y2)], fill=pil_color, width=1)
+
+    def Color(self, r, g, b):
+        """Create a color object."""
+        return PioMatterColor(r, g, b)
+
+    def Font(self):
+        """Create a font object."""
+        return PioMatterFont()

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -53,17 +53,23 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         # Initialize PioMatter (chain/parallel handled by geometry)
         print("DEBUG: Initializing PioMatter display")
         
-        # Determine pinout based on --led-gpio-mapping option or default to Regular
-        # Seekgreat boards typically use the Regular/Classic pinout
+        # List available pinouts for debugging
+        try:
+            available_pinouts = [attr for attr in dir(piomatter.Pinout) if not attr.startswith('_')]
+            print(f"DEBUG: Available pinouts: {available_pinouts}")
+        except Exception as e:
+            print(f"DEBUG: Could not list pinouts: {e}")
+        
+        # Determine pinout based on --led-gpio-mapping option
+        # Use AdafruitMatrixHat as default (most common for Pi5)
         pinout_map = {
             'adafruit-hat': piomatter.Pinout.AdafruitMatrixHat,
             'adafruit-hat-pwm': piomatter.Pinout.AdafruitMatrixHat,
-            'regular': piomatter.Pinout.Regular,
-            'classic': piomatter.Pinout.Regular,
         }
         
-        # Get the mapping from options if available, default to Regular for Seekgreat
-        pinout = pinout_map.get(getattr(options, 'hardware_mapping', 'regular').lower(), piomatter.Pinout.Regular)
+        # Get the mapping from options if available
+        hardware_mapping = getattr(options, 'hardware_mapping', 'adafruit-hat').lower()
+        pinout = pinout_map.get(hardware_mapping, piomatter.Pinout.AdafruitMatrixHat)
         print(f"DEBUG: Using pinout: {pinout}")
         
         self._matrix = piomatter.PioMatter(

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -59,6 +59,33 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
             geometry=self._geometry
         )
         print("DEBUG: PioMatter display initialized successfully")
+        
+        # Try to start/enable the display if such method exists
+        try:
+            if hasattr(self._matrix, 'start'):
+                print("DEBUG: Calling matrix.start()")
+                self._matrix.start()
+            if hasattr(self._matrix, 'enable'):
+                print("DEBUG: Calling matrix.enable()")
+                self._matrix.enable()
+        except Exception as e:
+            print(f"DEBUG: Could not start/enable matrix: {e}")
+        
+        # Do an initial show to activate the display
+        print("DEBUG: Doing initial matrix.show() to activate display")
+        try:
+            self._framebuffer[:] = 255  # Fill with white to test
+            self._matrix.show()
+            print("DEBUG: Initial show() completed - display should be white")
+            import time
+            time.sleep(2)
+            self._framebuffer[:] = 0  # Clear back to black
+            self._matrix.show()
+            print("DEBUG: Cleared to black")
+        except Exception as e:
+            print(f"ERROR in initial show: {e}")
+            import traceback
+            traceback.print_exc()
 
         self._width = width
         self._height = height

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -174,17 +174,18 @@ class PioMatterFont:
 
     def LoadFont(self, path):
         """Load a BDF font. Convert to PIL font."""
-        from PIL import ImageFont, BdfFontFile
+        from PIL import ImageFont, BdfFontFile, Image
         import os
         
         # Store the path for reference
         self._font_path = path
 
-        # Try to load BDF font using BdfFontFile (for standalone BDF files)
+        # Try to load BDF font using BdfFontFile and convert to PIL font
         try:
             with open(path, 'rb') as f:
-                bdf_font = BdfFontFile.BdfFontFile(f)
-                self._font = bdf_font
+                bdf = BdfFontFile.BdfFontFile(f)
+                # Convert BdfFontFile to a usable PIL font
+                self._font = bdf.getfont()
                 print(f"Successfully loaded BDF font: {path}")
                 return True
         except Exception as e:
@@ -195,14 +196,14 @@ class PioMatterFont:
             fallback_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 
                                          'assets', 'fonts', 'patched', '4x6.bdf')
             with open(fallback_path, 'rb') as f:
-                bdf_font = BdfFontFile.BdfFontFile(f)
-                self._font = bdf_font
+                bdf = BdfFontFile.BdfFontFile(f)
+                self._font = bdf.getfont()
                 print(f"Successfully loaded fallback BDF: {fallback_path}")
                 return True
         except Exception as e:
             print(f"Failed to load 4x6.bdf: {e}")
         
-        # Try loading a very small TrueType font (4-5 point size to approximate 4x6 pixels)
+        # Try loading a very small TrueType font (5 point size to approximate 4x6 pixels)
         try:
             # Try common monospace fonts at small size
             for ttf_path in [

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -46,9 +46,9 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         self._canvas = Image.new('RGB', (width, height), (0, 0, 0))
         self._draw = ImageDraw.Draw(self._canvas)
 
-        # Create framebuffer
+        # Create framebuffer - must be contiguous numpy array
         print("DEBUG: Creating framebuffer")
-        self._framebuffer = np.asarray(self._canvas).copy()
+        self._framebuffer = np.zeros((height, width, 3), dtype=np.uint8)
 
         # Initialize PioMatter (chain/parallel handled by geometry)
         print("DEBUG: Initializing PioMatter display")

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -277,13 +277,13 @@ class PioMatterGraphicsAdapter(GraphicsBase):
                             bbyoff = glyph.meta.get('bbyoff', 0)
                             dwx0 = glyph.meta.get('dwx0', bitmap.width())
                             
-                            # Get bitmap as 2D list (1=pixel set, 0=pixel clear)
+                            # Get bitmap as list of strings ('0' and '1' chars)
                             pixels = bitmap.todata(1)
                             
                             # Draw glyph bitmap
                             for row_idx, row in enumerate(pixels):
-                                for col_idx, pixel in enumerate(row):
-                                    if pixel:
+                                for col_idx, pixel_char in enumerate(row):
+                                    if pixel_char == '1':  # Check if character is '1'
                                         px = current_x + bbxoff + col_idx
                                         py = y - bbyoff - (len(pixels) - row_idx - 1)
                                         canvas._draw.point((px, py), fill=pil_color)

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -174,32 +174,47 @@ class PioMatterFont:
 
     def LoadFont(self, path):
         """Load a BDF font. Convert to PIL font."""
+        from PIL import ImageFont
+        import os
+        
         # Store the path for reference
         self._font_path = path
 
         # Try to load the requested BDF font first
         try:
-            from PIL import ImageFont
             self._font = ImageFont.load(path)
             return True
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Failed to load font {path}: {e}")
         
         # Fallback to 4x6.bdf
         try:
-            from PIL import ImageFont
-            import os
             fallback_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 
                                          'assets', 'fonts', 'patched', '4x6.bdf')
             self._font = ImageFont.load(fallback_path)
+            print(f"Using fallback font: {fallback_path}")
             return True
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Failed to load 4x6.bdf: {e}")
         
-        # Ultimate fallback to PIL default if 4x6 not found
+        # Try loading a very small TrueType font (4 point size to approximate 4x6 pixels)
         try:
-            from PIL import ImageFont
+            # Try common monospace fonts at 4pt to get approximately 4x6 pixels
+            for ttf_path in [
+                "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+                "/usr/share/fonts/truetype/liberation/LiberationMono-Regular.ttf",
+            ]:
+                if os.path.exists(ttf_path):
+                    self._font = ImageFont.truetype(ttf_path, size=6)  # 6pt font
+                    print(f"Using TrueType fallback at 6pt: {ttf_path}")
+                    return True
+        except Exception as e:
+            print(f"Failed to load TrueType font: {e}")
+        
+        # Ultimate fallback - create a minimal default
+        try:
             self._font = ImageFont.load_default()
+            print("Using PIL default font")
         except Exception:
             self._font = None
         

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -162,6 +162,7 @@ class PioMatterFont:
 
     def LoadFont(self, path):
         """Load a BDF font. Convert to PIL font."""
+        print(f"DEBUG: LoadFont called with path={path}")
         # Store the path for reference
         self._font_path = path
 
@@ -171,13 +172,18 @@ class PioMatterFont:
         try:
             # Try to load as BDF (PIL supports BDF)
             from PIL import ImageFont
+            print(f"DEBUG: Attempting to load BDF font: {path}")
             self._font = ImageFont.load(path)
-        except Exception:
+            print(f"DEBUG: BDF font loaded successfully")
+        except Exception as e:
+            print(f"DEBUG: BDF load failed ({e}), trying TrueType fallback")
             # Fall back to default font
             try:
                 # Try DejaVu Sans Mono which is commonly available
                 self._font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf", 10)
-            except Exception:
+                print(f"DEBUG: Using DejaVu Sans Mono fallback")
+            except Exception as e2:
+                print(f"DEBUG: TrueType fallback failed ({e2}), using default font")
                 # Ultimate fallback to default
                 self._font = ImageFont.load_default()
 
@@ -199,11 +205,20 @@ class PioMatterGraphicsAdapter(GraphicsBase):
 
     def DrawText(self, canvas, font, x, y, color, text):
         """Draw text using PIL."""
+        print(f"DEBUG: DrawText called - text='{text}', x={x}, y={y}")
         if isinstance(canvas, PioMatterCanvas):
-            pil_color = color.to_tuple() if isinstance(color, PioMatterColor) else color
-            # Note: PIL text baseline is different from hzeller, may need adjustment
-            canvas._draw.text((x, y - 10), text, fill=pil_color, font=font._font if hasattr(font, '_font') else None)
-            return len(text) * 6  # Approximate width
+            try:
+                pil_color = color.to_tuple() if isinstance(color, PioMatterColor) else color
+                print(f"DEBUG: Drawing text with color={pil_color}, font={font._font if hasattr(font, '_font') else None}")
+                # Note: PIL text baseline is different from hzeller, may need adjustment
+                canvas._draw.text((x, y - 10), text, fill=pil_color, font=font._font if hasattr(font, '_font') else None)
+                print(f"DEBUG: Text drawn successfully")
+                return len(text) * 6  # Approximate width
+            except Exception as e:
+                print(f"ERROR in DrawText: {e}")
+                import traceback
+                traceback.print_exc()
+                return 0
 
     def DrawLine(self, canvas, x1, y1, x2, y2, color):
         """Draw a line using PIL."""

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -75,10 +75,15 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
     def SwapOnVSync(self, canvas):
         """Swap buffers and update the display."""
         if isinstance(canvas, PioMatterCanvas):
-            # Copy canvas content to framebuffer
-            self._framebuffer[:] = np.asarray(canvas._image)
-            # Update the display
-            self._matrix.show()
+            try:
+                # Copy canvas content to framebuffer
+                self._framebuffer[:] = np.asarray(canvas._image)
+                # Update the display
+                self._matrix.show()
+            except Exception as e:
+                print(f"ERROR in SwapOnVSync: {e}")
+                import traceback
+                traceback.print_exc()
         return canvas
 
     def SetImage(self, image, offset_x=0, offset_y=0):

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -29,11 +29,12 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
             64: 5    # 1/32 scan
         }.get(panel_rows, 4)  # Default to 4 address lines
 
-        # Create geometry - PioMatter expects dimensions of a SINGLE panel
-        # The library handles chaining and parallel internally
+        # Create geometry - use total display dimensions
+        # For a single 64x32 panel: width=64, height=32
+        # PioMatter's geometry describes the overall display configuration
         self._geometry = piomatter.Geometry(
-            width=options.cols,  # Single panel width
-            height=panel_rows,    # Single panel height
+            width=width,  # Total width (cols * chain)
+            height=height,  # Total height (rows * parallel)
             n_addr_lines=n_addr_lines,
             rotation=piomatter.Orientation.Normal
         )
@@ -45,14 +46,12 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         # Create framebuffer
         self._framebuffer = np.asarray(self._canvas).copy()
 
-        # Initialize PioMatter with single panel geometry
+        # Initialize PioMatter (chain/parallel handled by geometry)
         self._matrix = piomatter.PioMatter(
             colorspace=piomatter.Colorspace.RGB888Packed,
             pinout=piomatter.Pinout.AdafruitMatrixBonnet,
             framebuffer=self._framebuffer,
-            geometry=self._geometry,
-            chain=options.chain_length,
-            parallel=options.parallel
+            geometry=self._geometry
         )
 
         self._width = width

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -61,16 +61,20 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
             print(f"DEBUG: Could not list pinouts: {e}")
         
         # Determine pinout based on --led-gpio-mapping option
-        # Use AdafruitMatrixHat as default (most common for Pi5)
+        # Default to Active3 for Seekgreat and similar boards
         pinout_map = {
             'adafruit-hat': piomatter.Pinout.AdafruitMatrixHat,
             'adafruit-hat-pwm': piomatter.Pinout.AdafruitMatrixHat,
+            'adafruit-bonnet': piomatter.Pinout.AdafruitMatrixBonnet,
+            'regular': piomatter.Pinout.Active3,
+            'classic': piomatter.Pinout.Active3,
+            'active3': piomatter.Pinout.Active3,
         }
         
-        # Get the mapping from options if available
-        hardware_mapping = getattr(options, 'hardware_mapping', 'adafruit-hat').lower()
-        pinout = pinout_map.get(hardware_mapping, piomatter.Pinout.AdafruitMatrixHat)
-        print(f"DEBUG: Using pinout: {pinout}")
+        # Get the mapping from options if available, default to Active3
+        hardware_mapping = getattr(options, 'hardware_mapping', 'active3').lower()
+        pinout = pinout_map.get(hardware_mapping, piomatter.Pinout.Active3)
+        print(f"DEBUG: Using pinout: {pinout} (from mapping: {hardware_mapping})")
         
         self._matrix = piomatter.PioMatter(
             colorspace=piomatter.Colorspace.RGB888Packed,

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -52,9 +52,23 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
 
         # Initialize PioMatter (chain/parallel handled by geometry)
         print("DEBUG: Initializing PioMatter display")
+        
+        # Determine pinout based on --led-gpio-mapping option or default to Regular
+        # Seekgreat boards typically use the Regular/Classic pinout
+        pinout_map = {
+            'adafruit-hat': piomatter.Pinout.AdafruitMatrixHat,
+            'adafruit-hat-pwm': piomatter.Pinout.AdafruitMatrixHat,
+            'regular': piomatter.Pinout.Regular,
+            'classic': piomatter.Pinout.Regular,
+        }
+        
+        # Get the mapping from options if available, default to Regular for Seekgreat
+        pinout = pinout_map.get(getattr(options, 'hardware_mapping', 'regular').lower(), piomatter.Pinout.Regular)
+        print(f"DEBUG: Using pinout: {pinout}")
+        
         self._matrix = piomatter.PioMatter(
             colorspace=piomatter.Colorspace.RGB888Packed,
-            pinout=piomatter.Pinout.AdafruitMatrixBonnet,
+            pinout=pinout,
             framebuffer=self._framebuffer,
             geometry=self._geometry
         )

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -22,12 +22,13 @@ class PioMatterMatrixAdapter(MatrixDriverBase):
         # Determine number of address lines based on panel rows
         # 64x32 panels typically use 1/16 scan = 4 address lines
         # 64x64 panels typically use 1/32 scan = 5 address lines
+        # Some boards (like Seekgreat) use 1-based addressing, requiring 5 lines for 32-row panels
         panel_rows = options.rows  # Single panel height
         n_addr_lines = {
             16: 4,   # 1/16 scan
-            32: 4,   # 1/16 scan (most common for 64x32 panels)
-            64: 5    # 1/32 scan
-        }.get(panel_rows, 4)  # Default to 4 address lines
+            32: 5,   # 1/32 scan (for boards with 1-based addressing like Seekgreat)
+            64: 6    # 1/64 scan
+        }.get(panel_rows, 5)  # Default to 5 address lines
 
         # Create geometry - use total display dimensions
         # For a single 64x32 panel: width=64, height=32

--- a/driver/piomatter_adapter.py
+++ b/driver/piomatter_adapter.py
@@ -128,6 +128,10 @@ class PioMatterColor:
         self.r = r
         self.g = g
         self.b = b
+        # Aliases for compatibility
+        self.red = r
+        self.green = g
+        self.blue = b
 
     def to_tuple(self):
         return (self.r, self.g, self.b)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 # Important! Import the driver first to initialize it, then import submodules as needed.
 import driver
-from driver import RGBMatrix, __version__
 from utils import args, led_matrix_options
 
 from data import Data
@@ -54,9 +53,11 @@ def main(matrix, config_base):
         if driver.hardware_load_failed:
             debug.log("rgbmatrix not installed, falling back to emulator!")
 
-        debug.log("Using RGBMatrixEmulator version %s", __version__)
+        debug.log("Using RGBMatrixEmulator version %s", getattr(driver, '__version__', 'unknown'))
     else:
-        debug.log("Using rgbmatrix version %s", __version__)
+        debug.log("Using %s driver version %s", 
+                  "Pi 5 (PioMatter)" if driver.is_pi5() else "rgbmatrix",
+                  getattr(driver, '__version__', 'unknown'))
 
     # Draw startup screen
     logo_filename = "mlb-w{}h{}.png".format(matrix.width, matrix.height)
@@ -166,8 +167,8 @@ if __name__ == "__main__":
         matrixOptions.emulator_title = f"{SCRIPT_NAME} v{SCRIPT_VERSION}"
         matrixOptions.icon_path = (Path(__file__).parent / "assets" / "mlb-emulator-icon.png").resolve()
 
-    # Initialize the matrix
-    matrix = RGBMatrix(options=matrixOptions)
+    # Initialize the matrix using the driver factory method
+    matrix = driver.RGBMatrix(options=matrixOptions)
     try:
         config, _ = os.path.splitext(command_line_args.config)
         main(matrix, config)

--- a/requirements-pi5.txt
+++ b/requirements-pi5.txt
@@ -1,0 +1,10 @@
+# Raspberry Pi 5 specific requirements
+# Install these in addition to main requirements.txt when using Pi 5
+
+# Adafruit Blinka PioMatter for Pi 5 RGB Matrix support
+adafruit-blinka>=8.0.0
+Adafruit-Blinka-Raspberry-Pi5-Piomatter>=0.1.0
+
+# Image processing (already in main requirements but included for completeness)
+Pillow>=9.0.0
+numpy>=1.20.0

--- a/test_pinouts.py
+++ b/test_pinouts.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Test different pinouts to find the right one for your board."""
+
+import adafruit_blinka_raspberry_pi5_piomatter as piomatter
+import numpy as np
+import time
+
+# Test parameters
+width = 64
+height = 32
+n_addr_lines = 4
+
+# Available pinouts to test
+pinouts_to_test = [
+    ('AdafruitMatrixHat', piomatter.Pinout.AdafruitMatrixHat),
+    ('AdafruitMatrixBonnet', piomatter.Pinout.AdafruitMatrixBonnet),
+    ('Active3', piomatter.Pinout.Active3),
+    ('AdafruitMatrixHatBGR', piomatter.Pinout.AdafruitMatrixHatBGR),
+    ('AdafruitMatrixBonnetBGR', piomatter.Pinout.AdafruitMatrixBonnetBGR),
+    ('Active3BGR', piomatter.Pinout.Active3BGR),
+]
+
+print(f"Testing {len(pinouts_to_test)} pinouts on {width}x{height} display...")
+print("Watch your display - it should flash RED for each pinout that works.\n")
+
+for name, pinout in pinouts_to_test:
+    print(f"\n{'='*60}")
+    print(f"Testing: {name}")
+    print(f"{'='*60}")
+    
+    try:
+        # Create geometry
+        geometry = piomatter.Geometry(
+            width=width,
+            height=height,
+            n_addr_lines=n_addr_lines,
+            rotation=piomatter.Orientation.Normal
+        )
+        
+        # Create framebuffer
+        framebuffer = np.zeros((height, width, 3), dtype=np.uint8)
+        
+        # Initialize display
+        matrix = piomatter.PioMatter(
+            colorspace=piomatter.Colorspace.RGB888Packed,
+            pinout=pinout,
+            framebuffer=framebuffer,
+            geometry=geometry
+        )
+        
+        print(f"✓ {name} initialized successfully")
+        
+        # Test 1: Fill RED
+        print("  Testing RED...")
+        framebuffer[:, :] = [255, 0, 0]  # RGB Red
+        matrix.show()
+        time.sleep(2)
+        
+        # Test 2: Fill GREEN
+        print("  Testing GREEN...")
+        framebuffer[:, :] = [0, 255, 0]  # RGB Green
+        matrix.show()
+        time.sleep(2)
+        
+        # Test 3: Fill BLUE
+        print("  Testing BLUE...")
+        framebuffer[:, :] = [0, 0, 255]  # RGB Blue
+        matrix.show()
+        time.sleep(2)
+        
+        # Clear
+        framebuffer[:, :] = 0
+        matrix.show()
+        
+        print(f"✓ {name} completed - did you see RED/GREEN/BLUE flashes?")
+        
+        # Cleanup
+        del matrix
+        
+    except Exception as e:
+        print(f"✗ {name} failed: {e}")
+    
+    time.sleep(1)
+
+print("\n" + "="*60)
+print("Test complete!")
+print("Which pinout showed colors correctly on your display?")
+print("="*60)

--- a/utils.py
+++ b/utils.py
@@ -127,6 +127,12 @@ def args():
         const=True
     )
     parser.add_argument(
+        "--pi5",
+        action="store_const",
+        help="Use Raspberry Pi 5 driver (Adafruit PioMatter). Required for Pi 5.",
+        const=True
+    )
+    parser.add_argument(
         "--drop-privileges", action="store_true", help="Force the matrix driver to drop root privileges after setup."
     )
     return parser.parse_args()


### PR DESCRIPTION
## Summary
This PR adds full Raspberry Pi 5 support to mlb-led-scoreboard while maintaining 100% backward compatibility with Pi 4 and earlier.

## Changes
- **Driver Abstraction Layer**: Created base classes for matrix drivers to support multiple hardware backends
- **Pi 5 Driver**: Implemented PioMatter adapter using Adafruit's Blinka PioMatter library for Pi 5
- **Pi 4 Driver**: Wrapped existing hzeller rgbmatrix library in adapter for consistency
- **Hardware Support**: Tested and working with Seekgreat RGB Matrix Adapter Board Rev 3.8
- **Command-line Flag**: Added `--pi5` flag to enable Pi 5 mode
- **Documentation**: Comprehensive README-PI5.md with setup instructions and troubleshooting
- **Pinout Testing**: Included test script to help users identify correct GPIO pinout for their board

## Hardware Compatibility
### Raspberry Pi 5:
- Active3 pinout (default) - Seekgreat and similar boards
- AdafruitMatrixHat - Adafruit Matrix HAT
- AdafruitMatrixBonnet - Adafruit Matrix Bonnet

### Raspberry Pi 4 and earlier:
- All existing functionality unchanged
- No modifications needed to existing setups

## Usage
```bash
# Raspberry Pi 5
sudo python3 main.py --pi5 --led-rows=32 --led-cols=64

# Raspberry Pi 4 and earlier (unchanged)
sudo python3 main.py --led-rows=32 --led-cols=64
```

## Testing
- ✅ Successfully tested on Raspberry Pi 5 with 64x32 panel
- ✅ Confirmed working with Seekgreat RGB Matrix Adapter Board Rev 3.8
- ✅ Backward compatible - no changes required for existing Pi 4 users
- ✅ No existing unit tests affected (tests cover data/config, not drivers)

## Files Added
- `driver/base.py` - Abstract base classes
- `driver/hzeller_adapter.py` - Pi 4 adapter
- `driver/piomatter_adapter.py` - Pi 5 adapter  
- `requirements-pi5.txt` - Pi 5 dependencies
- `README-PI5.md` - Pi 5 setup guide
- `test_pinouts.py` - Hardware testing utility

## Files Modified
- `driver/__init__.py` - Factory pattern for driver selection
- `driver/mode.py` - Added HARDWARE_PI5 mode
- `main.py` - Uses driver factory
- `utils.py` - Added --pi5 flag

Closes #XXX (if there's a related issue)