### PR TITLE
Add configuration options for leagues

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ A default `config.example.json` file is included for reference. Copy this file t
 "preferred":                              Options for team and division preference
   "teams"                         Array   An array of preferred teams. The first team in the list will be used as your 'favorite' team. Example: ["Cubs", "Brewers"]
   "divisions"                     Array   An array of preferred divisions that will be rotated through in the order they are entered. Example: ["NL Central", "AL Central"]
+  "leagues"                       Array   An array of preferred leagues. Teams from any league can be included in preferred_teams. Example: ["MLB", "WBC", "Olympics"]. Defaults to ["MLB"]
 
 "news_ticker":                            Options for displaying a nice clock/weather/news ticker screen
   "always_display"                Bool    Display the news ticker screen at all times. Supercedes the standings setting.

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,8 @@
 {
 	"preferred": {
 		"teams": ["Cubs"],
-		"divisions": ["NL Central", "NL Wild Card"]
+		"divisions": ["NL Central", "NL Wild Card"],
+		"leagues": ["MLB"]
 	},
 	"news_ticker": {
 		"team_offday": true,

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -8,7 +8,8 @@ import debug
 from data import status
 from data.config.color import Color
 from data.config.layout import Layout
-from data.time_formats import TIME_FORMAT_12H, TIME_FORMAT_24H
+from data.time_formats import TIME_FORMAT_12H, TIME_FORMAT_24H, os_datetime_format
+from data.schedule import LEAGUES, DEFAULT_LEAGUE
 from utils import deep_update
 
 SCROLLING_SPEEDS = [0.3, 0.2, 0.1, 0.075, 0.05, 0.025, 0.01]
@@ -18,15 +19,17 @@ MINIMUM_ROTATE_RATE = 2.0
 DEFAULT_ROTATE_RATES = {"live": DEFAULT_ROTATE_RATE, "final": DEFAULT_ROTATE_RATE, "pregame": DEFAULT_ROTATE_RATE}
 DEFAULT_PREFERRED_TEAMS = ["Cubs"]
 DEFAULT_PREFERRED_DIVISIONS = ["NL Central"]
+DEFAULT_PREFERRED_LEAGUE = DEFAULT_LEAGUE
 
 
 class Config:
     def __init__(self, filename_base, width, height):
         json = self.__get_config(filename_base)
 
-        # Preferred Teams/Divisions
+        # Preferred Teams/Divisions/Leagues
         self.preferred_teams = json["preferred"]["teams"]
         self.preferred_divisions = json["preferred"]["divisions"]
+        self.preferred_leagues = json["preferred"]["leagues"]
 
         # News Ticker
         self.news_ticker_team_offday = json["news_ticker"]["team_offday"]
@@ -36,7 +39,7 @@ class Config:
         self.news_ticker_mlb_news = json["news_ticker"]["mlb_news"]
         self.news_ticker_countdowns = json["news_ticker"]["countdowns"]
         self.news_ticker_date = json["news_ticker"]["date"]
-        self.news_ticker_date_format = json["news_ticker"]["date_format"]
+        self.news_ticker_date_format = os_datetime_format(json["news_ticker"]["date_format"])
         self.news_no_games = json["news_ticker"]["display_no_games_live"]
 
         # Display Standings
@@ -98,6 +101,7 @@ class Config:
         self.check_time_format()
         self.check_preferred_teams()
         self.check_preferred_divisions()
+        self.check_preferred_leagues()
 
         # Check the rotation_rates to make sure it's valid and not silly
         self.check_rotate_rates()
@@ -114,6 +118,39 @@ class Config:
         if isinstance(self.preferred_teams, str):
             team = self.preferred_teams
             self.preferred_teams = [team]
+
+    def check_preferred_leagues(self):
+        if not isinstance(self.preferred_leagues, str) and not isinstance(self.preferred_leagues, list):
+            debug.warning(
+                "preferred_league should be an array of team names or a single team name string."
+                "Using default preferred_league, {}".format(DEFAULT_PREFERRED_LEAGUE)
+            )
+            self.preferred_leagues = [DEFAULT_PREFERRED_LEAGUE]
+
+        leagues = []
+        invalid_leagues = []
+
+        for league_name in self.preferred_leagues:
+            if league_name in LEAGUES:
+                leagues.append(league_name)
+            else:
+                invalid_leagues.append(league_name)
+
+        if invalid_leagues:
+            debug.warning(
+                'Removing unknown league names [{}], must be one of [{}]'.format(
+                    ", ".join(f'{sport}' for sport in invalid_leagues),
+                    ", ".join(f'{sport}' for sport in LEAGUES.keys())
+                )
+            )
+
+        if not leagues:
+            debug.warning(
+                "No valid league name listed! Defaulting to '{}'...".format(DEFAULT_PREFERRED_LEAGUE)
+            )
+            leagues = [DEFAULT_PREFERRED_LEAGUE]
+
+        self.preferred_leagues = leagues
 
     def check_delay(self):
         if self.preferred_game_delay_multiplier < 0:

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -10,6 +10,12 @@ from data.update import UpdateStatus
 
 GAMES_REFRESH_RATE = 6 * 60
 
+LEAGUES = {
+    "MLB": "1",
+    "WBC": "52",
+    "Olympics": "52"
+}
+DEFAULT_LEAGUE = "MLB"
 
 class Schedule:
     def __init__(self, config):
@@ -29,8 +35,8 @@ class Schedule:
             debug.log("Updating schedule for %s", self.date)
             self.starttime = time.time()
             try:
-                # add sportId=51 to additionally get WBC games
-                self.__all_games = statsapi.schedule(self.date.strftime("%Y-%m-%d"), sportId="1,51")
+                sport_ids = [LEAGUES[league] for league in self.config.preferred_leagues]
+                self.__all_games = statsapi.schedule(self.date.strftime("%Y-%m-%d"), sportId=",".join(sport_ids))
             except:
                 debug.exception("Networking error while refreshing schedule")
                 return UpdateStatus.FAIL

--- a/data/time_formats.py
+++ b/data/time_formats.py
@@ -1,4 +1,25 @@
 import platform
 
+
+WINDOWS_DISABLE_PADDING_SYMBOL = "#"
+DEFAULT_DISABLE_PADDING_SYMBOL = "-"
+
+def os_datetime_format(format_str):
+    '''
+    Converts Windows-based strftime() format code to a Unix code and vice versa.
+    For example, datetime.date(2025, 1, 1).strftime() with a format string '%Y %m %d'
+    left pads the month/day with zeros to two digits, resulting in '2025 01 01'.
+    Unix systems disable zero padding with '-', while Windows does so with '#'.
+    If the format string has an incompatible character, strftime() can fail.
+    The following format strings are equivalent, and both result in to '2025 1 1'.
+      Windows : '%Y %#m %#d'
+      Unix    : '%Y %-m %-d'
+    '''
+    if platform.system() == "Windows":
+        return format_str.replace(DEFAULT_DISABLE_PADDING_SYMBOL, WINDOWS_DISABLE_PADDING_SYMBOL)
+    else:
+        return format_str.replace(WINDOWS_DISABLE_PADDING_SYMBOL, DEFAULT_DISABLE_PADDING_SYMBOL)
+
+TIME_FORMAT_12H = os_datetime_format("%-I")
 TIME_FORMAT_24H = "%H"
-TIME_FORMAT_12H = "%#I" if platform.system() == "Windows" else "%-I"
+


### PR DESCRIPTION
This allows us to turn off WBC functionality via config. Disabled by default

Sets us up to support all the sport IDs that StatsAPI supports, notably 2028 summer Olympics

I also extracted a time format helper from #664 primarily to help with emulation crashes on Windows