### PR TITLE
Better path support for configs

### DIFF
--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -8,6 +8,7 @@ import debug
 from data import status
 from data.config.color import Color
 from data.config.layout import Layout
+from data.paths import *
 from data.time_formats import TIME_FORMAT_12H, TIME_FORMAT_24H, os_datetime_format
 from utils import deep_update
 
@@ -21,8 +22,8 @@ DEFAULT_PREFERRED_DIVISIONS = ["NL Central"]
 
 
 class Config:
-    def __init__(self, filename_base, width, height):
-        json = self.__get_config(filename_base)
+    def __init__(self, config_path, width, height):
+        json = self.__get_config(config_path)
 
         # Preferred Teams/Divisions
         self.preferred_teams = json["preferred"]["teams"]
@@ -212,33 +213,43 @@ class Config:
         If file not present return empty data.
         Exception if json invalid.
         """
-        j = {}
-        if os.path.isfile(path):
-            j = json.load(open(path))
-        else:
-            debug.info(f"Could not find json file {path}.  Skipping.")
-        return j
+        if not os.path.isfile(path):
+            return {}
+        
+        return json.load(open(path))
 
-    # example config is a "base config" which always gets read.
-    # our "custom" config contains overrides.
-    def __get_config(self, base_filename):
-        filename = "{}.json".format(base_filename)
-        reference_filename = "config.example.json"  # always use this filename.
-        reference_config = self.read_json(reference_filename)
-        custom_config = self.read_json(filename)
+    def __get_config(self, path=None):
+        if path is None:
+            path = ROOT_DIRECTORY / "config.json"
+        else:
+            path = (CURRENT_DIRECTORY / path).with_suffix(".json")
+        reference_filename = "config.example.json"
+        reference_path = ROOT_DIRECTORY / reference_filename
+        reference_config = self.read_json(reference_path)
+        custom_config = self.read_json(path)
+        if not reference_config:
+            debug.critical(f"""\
+Invalid example configuration. Make sure {reference_filename} exists in root directory.
+You should not edit or move this file!
+"""
+            )
+            sys.exit(1)
+
         if custom_config:
             new_config = deep_update(reference_config, custom_config)
             return new_config
         return reference_config
 
     def __get_colors(self, base_filename):
-        filename_prefix = "colors/{}".format(base_filename)
-        filename = "{}.json".format(filename_prefix)
-        reference_filename = "{}.example.json".format(filename_prefix)
-        reference_colors = self.read_json(reference_filename)
+        filename = "{}.json".format(base_filename)
+        reference_filename = "{}.example.json".format(base_filename)
+        reference_path = COLORS_DIRECTORY / reference_filename
+        reference_colors = self.read_json(reference_path)
         if not reference_colors:
-            debug.error(
-                "Invalid {} reference color file. Make sure {} exists in colors/".format(base_filename, base_filename)
+            debug.critical(f"""\
+Invalid reference color file. Make sure {reference_filename} exists in colors/.
+You should not edit or move this file!"
+"""
             )
             sys.exit(1)
 
@@ -250,15 +261,20 @@ class Config:
         return reference_colors
 
     def __get_layout(self, width, height):
-        filename_prefix = "coordinates/w{}h{}".format(width, height)
+        filename_prefix = "w{}h{}".format(width, height)
         filename = "{}.json".format(filename_prefix)
         reference_filename = "{}.example.json".format(filename_prefix)
-        reference_layout = self.read_json(reference_filename)
+        reference_path = COORDINATES_DIRECTORY / reference_filename
+        reference_layout = self.read_json(reference_path)
         if not reference_layout:
-            # Unsupported coordinates
-            debug.error(
-                "Invalid matrix dimensions provided. See top of README for supported dimensions."
-                "\nIf you would like to see new dimensions supported, please file an issue on GitHub!"
+            supported_dimensions = sorted([file.name.split(".")[0] for file in COORDINATES_DIRECTORY.glob("*.example.json")], reverse=True)
+            debug.critical(f"""\
+Invalid reference layout file. Make sure {reference_filename} exists in coordinates/
+You should not edit or move this file!
+
+Supported dimensions are: {', '.join(supported_dimensions)}
+If you aren't sure why you're seeing this, there might not be official support for your matrix dimensions yet.
+"""
             )
             sys.exit(1)
 

--- a/data/paths.py
+++ b/data/paths.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+"""Centralized path constants for locating project directories at runtime."""
+CURRENT_DIRECTORY     = Path.cwd()
+ROOT_DIRECTORY        = (Path(__file__) / ".." / "..").resolve()
+COORDINATES_DIRECTORY = ROOT_DIRECTORY / "coordinates"
+COLORS_DIRECTORY      = ROOT_DIRECTORY / "colors"

--- a/data/weather.py
+++ b/data/weather.py
@@ -73,17 +73,14 @@ class Weather:
                 except pyowm.commons.exceptions.APIRequestError:
                     debug.warning("[WEATHER] Fetching weather information failed from a connection issue.")
                     debug.exception("[WEATHER] Error Message:")
-                    # Set some placeholder weather info if this is our first weather update
-                    if self.temp is None:
-                        self.temp = -99
-                    if self.wind_speed is None:
-                        self.wind_speed = -9
-                    if self.wind_dir is None:
-                        self.wind_dir = 0
-                    if self.conditions is None:
-                        self.conditions = "Error"
-                    if self.icon_name is None:
-                        self.icon_name = "50d"
+                    self.__set_fail_state_defaults()
+                    return UpdateStatus.FAIL
+                except pyowm.commons.exceptions.NotFoundError:
+                    debug.warning("[WEATHER] Fetching weather information failed from a not found error.")
+                    debug.warning("[WEATHER] The 'weather.location' config is likely not formatted correctly.")
+                    debug.warning("[WEATHER] The correct format is '<city>,<state>,<country>' (example: 'Chicago,il,us')")
+                    debug.exception("[WEATHER] Error Message:")
+                    self.__set_fail_state_defaults()
                     return UpdateStatus.FAIL
 
         return UpdateStatus.DEFERRED
@@ -113,3 +110,16 @@ class Weather:
         val = int((degrees / 22.5) + 0.5)
         arr = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"]
         return arr[(val % 16)]
+
+    def __set_fail_state_defaults(self):
+        # Set some placeholder weather info if this is our first weather update
+        if self.temp is None:
+            self.temp = -99
+        if self.wind_speed is None:
+            self.wind_speed = -9
+        if self.wind_dir is None:
+            self.wind_dir = 0
+        if self.conditions is None:
+            self.conditions = "Error"
+        if self.icon_name is None:
+            self.icon_name = "50d"

--- a/debug.py
+++ b/debug.py
@@ -24,4 +24,5 @@ log = logger.debug
 info = logger.info
 warning = logger.warning
 error = logger.error
+critical = logger.critical
 exception = logger.exception

--- a/main.py
+++ b/main.py
@@ -157,8 +157,8 @@ def __render_main(matrix, data):
 
 if __name__ == "__main__":
     # Check for led configuration arguments
-    command_line_args = args()
-    matrixOptions = led_matrix_options(command_line_args)
+    clargs = args()
+    matrixOptions = led_matrix_options(clargs)
 
     if driver.is_emulated():
         matrixOptions.emulator_title = f"{SCRIPT_NAME} v{SCRIPT_VERSION}"
@@ -167,8 +167,7 @@ if __name__ == "__main__":
     # Initialize the matrix
     matrix = RGBMatrix(options=matrixOptions)
     try:
-        config, _ = os.path.splitext(command_line_args.config)
-        main(matrix, config)
+        main(matrix, clargs.config)
     except:
         debug.exception("Untrapped error in main!")
         sys.exit(1)

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -124,9 +124,9 @@ class TestValidateConfigMethods(unittest.TestCase):
         self.assertEqual(
           custom_config_files(),
           [
-            (ROOT_DIR, "config.json", { "ignored_keys": [], "renamed_keys": {"preferred_game_update_delay_in_10s_of_seconds": "preferred_game_delay_multiplier"} }),
-            (COORDINATES_DIR, "config.json", { "ignored_keys": COORDINATES_IGNORED_KEYS, "renamed_keys": {} }),
-            (COLORS_DIR, "config.json", { "ignored_keys": COLORS_IGNORED_KEYS, "renamed_keys": {} }),
+            (ROOT_DIRECTORY, "config.json", { "ignored_keys": [], "renamed_keys": {"preferred_game_update_delay_in_10s_of_seconds": "preferred_game_delay_multiplier"} }),
+            (COORDINATES_DIRECTORY, "config.json", { "ignored_keys": COORDINATES_IGNORED_KEYS, "renamed_keys": {} }),
+            (COLORS_DIRECTORY, "config.json", { "ignored_keys": COLORS_IGNORED_KEYS, "renamed_keys": {} }),
           ]
         )
 

--- a/utils.py
+++ b/utils.py
@@ -116,8 +116,8 @@ def args():
     parser.add_argument(
         "--config",
         action="store",
-        help="Base file name for config file. Can use relative path, e.g. config/rockies.config",
-        default="config",
+        help="Relative path to a custom config JSON file. Defaults to root config.json. The '.json' suffix is optional.",
+        default=None,
         type=str,
     )
     parser.add_argument(

--- a/validate_config.py
+++ b/validate_config.py
@@ -1,17 +1,15 @@
 import copy, json, os
 
-ROOT_DIR        = "."
-COORDINATES_DIR = os.path.join(ROOT_DIR, "coordinates")
-COLORS_DIR      = os.path.join(ROOT_DIR, "colors")
+from data.paths import *
 
 VALIDATIONS = {
-  ROOT_DIR: {
+  ROOT_DIRECTORY: {
     "ignored_keys": [],
     "renamed_keys": {
       "preferred_game_update_delay_in_10s_of_seconds": "preferred_game_delay_multiplier",
     },
   },
-  COORDINATES_DIR: {
+  COORDINATES_DIRECTORY: {
     "ignored_keys": [
       "font_name",
       "no_hitter",
@@ -20,7 +18,7 @@ VALIDATIONS = {
     ],
     "renamed_keys": {},
   },
-  COLORS_DIR: {
+  COLORS_DIRECTORY: {
     "ignored_keys": [
       "city_connect"
     ],


### PR DESCRIPTION
Running the project from outside the project directory currently breaks because it can't find the right config schemas

This updates the path lookups to be relative to project root

* Fixes the bug with starting the project from an arbitrary location
* maintains support for the `--config` option, and better handles relative paths. Previously only supported child paths of project root, now you can put configs anywhere. `.json` file extension is optional
* Centralizes the directories in case we need to load files in the future. Updates a few tests to use them.
* Fixes a secondary bug where typos in the weather location caused a crash