### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/run_unittest_on_pr_open.yml
+++ b/.github/workflows/run_unittest_on_pr_open.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mlb-led-scoreboard
 
-![Current Version](https://img.shields.io/github/v/release/MLB-LED-Scoreboard/MLB-LED-Scoreboard) ![](https://img.shields.io/badge/python-3.9+-blue)
+![Current Version](https://img.shields.io/github/v/release/MLB-LED-Scoreboard/MLB-LED-Scoreboard) ![](https://img.shields.io/badge/python-3.10+-blue)
 
 [![Join Discord](https://img.shields.io/badge/discord-join-green.svg)](https://discord.gg/FdD6ec9fdt)
 

--- a/main.py
+++ b/main.py
@@ -3,8 +3,8 @@ import sys
 from data.screens import ScreenType
 import debug
 
-if sys.version_info < (3, 9):
-    debug.error("Please run with Python >= 3.9")
+if sys.version_info < (3, 10):
+    debug.error("Please run with Python >= 3.10")
     sys.exit(1)
 
 import statsapi


### PR DESCRIPTION
Python 3.9 is EOL as of 10-25.

Potentially disruptive since this project typically runs on system Python as part of Pi OS distro.

At minimum a minor version bump?