### PR TITLE
Move debug print inside game, typing cleanup

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -6,16 +6,13 @@ from data import status
 from data.game import Game
 from data.headlines import Headlines
 from data.schedule import Schedule
-from data.scoreboard import Scoreboard
-from data.scoreboard.postgame import Postgame
-from data.scoreboard.pregame import Pregame
 from data.standings import Standings
 from data.update import UpdateStatus
 from data.weather import Weather
 
 
 class Data:
-    def __init__(self, config):
+    def __init__(self, config) -> None:
         # Save the parsed config
         self.config = config
 
@@ -26,7 +23,6 @@ class Data:
 
         self.game_changed_time = time.time()
         if self.current_game is not None:
-            self.print_game_data_debug()
             self.__update_layout_state()
 
         # Weather info
@@ -73,7 +69,6 @@ class Data:
         status = self.current_game.update()
         if status == UpdateStatus.SUCCESS:
             self.__update_layout_state()
-            self.print_game_data_debug()
             self.network_issues = False
         elif status == UpdateStatus.FAIL:
             self.network_issues = True
@@ -89,7 +84,6 @@ class Data:
             self.current_game = game
             self.game_changed_time = time.time()
             self.__update_layout_state()
-            self.print_game_data_debug()
             self.network_issues = False
 
         elif self.current_game is not None:
@@ -150,9 +144,3 @@ class Data:
         if self.current_game.is_perfect_game():
             self.config.layout.set_state(layout.LAYOUT_STATE_PERFECT)
 
-    def print_game_data_debug(self):
-        debug.log("Game Data Refreshed: %s", self.current_game._current_data["gameData"]["game"]["id"])
-        debug.log("Current game is %d seconds behind", self.current_game.current_delay())
-        debug.log("Pre: %s", Pregame(self.current_game, self.config.time_format))
-        debug.log("Live: %s", Scoreboard(self.current_game))
-        debug.log("Final: %s", Postgame(self.current_game))

--- a/data/game.py
+++ b/data/game.py
@@ -9,6 +9,10 @@ from data import teams
 from data.update import UpdateStatus
 from data.delay_buffer import CircularQueue
 from data.uniforms import Uniforms
+from data.scoreboard import Scoreboard
+from data.scoreboard.postgame import Postgame
+from data.scoreboard.pregame import Pregame
+from data.time_formats import TIME_FORMAT_24H
 import data.headers
 
 API_FIELDS = (
@@ -23,6 +27,7 @@ API_FIELDS = (
 SCHEDULE_API_FIELDS = "dates,date,games,status,detailedState,abstractGameState,reason"
 
 GAME_UPDATE_RATE = 10
+
 
 class Game:
     @staticmethod
@@ -56,7 +61,11 @@ class Game:
             self.starttime = time.time()
             try:
                 debug.log("Fetching data for game %s", str(self.game_id))
-                live_data = statsapi.get("game", {"gamePk": self.game_id, "fields": API_FIELDS} | testing_params, request_kwargs={"headers": data.headers.API_HEADERS} )
+                live_data = statsapi.get(
+                    "game",
+                    {"gamePk": self.game_id, "fields": API_FIELDS} | testing_params,
+                    request_kwargs={"headers": data.headers.API_HEADERS},
+                )
                 # we add a delay to avoid spoilers. During construction, this will still yield live data, but then
                 # it will recycle that data until the queue is full.
                 self._data_wait_queue.push(live_data)
@@ -67,7 +76,9 @@ class Game:
                     debug.log("Getting game status from schedule for game with strange date!")
                     try:
                         scheduled = statsapi.get(
-                            "schedule", {"gamePk": self.game_id, "sportId": 1, "fields": SCHEDULE_API_FIELDS}, request_kwargs={"headers": data.headers.API_HEADERS}
+                            "schedule",
+                            {"gamePk": self.game_id, "sportId": 1, "fields": SCHEDULE_API_FIELDS},
+                            request_kwargs={"headers": data.headers.API_HEADERS},
                         )
                         self._status = next(
                             g["games"][0]["status"] for g in scheduled["dates"] if g["date"] == self.date
@@ -76,6 +87,7 @@ class Game:
                         debug.error("Failed to get game status from schedule")
 
                 self._uniform_data.update()
+                self.print_game_data_debug()
                 return UpdateStatus.SUCCESS
             except:
                 debug.exception("Networking Error while refreshing the current game data.")
@@ -348,3 +360,10 @@ class Game:
     @staticmethod
     def _format_id(player):
         return player if "ID" in str(player) else "ID" + str(player)
+
+    def print_game_data_debug(self):
+        debug.log("Game Data Refreshed: %s", self._current_data["gameData"]["game"]["id"])
+        debug.log("Game is %d seconds behind", self.current_delay())
+        debug.log("Pre: %s", Pregame(self, TIME_FORMAT_24H))
+        debug.log("Live: %s", Scoreboard(self))
+        debug.log("Final: %s", Postgame(self))

--- a/data/scoreboard/__init__.py
+++ b/data/scoreboard/__init__.py
@@ -1,4 +1,5 @@
-from data.game import Game
+from typing import TYPE_CHECKING
+
 from data.scoreboard.atbat import AtBat
 from data.scoreboard.bases import Bases
 from data.scoreboard.inning import Inning
@@ -7,6 +8,8 @@ from data.scoreboard.pitches import Pitches
 from data.scoreboard.team import Team
 from data import plays
 
+if TYPE_CHECKING:
+    from data.game import Game
 
 
 class Scoreboard:
@@ -15,7 +18,7 @@ class Scoreboard:
     including runners on base, balls, strikes, and outs.
     """
 
-    def __init__(self, game: Game):
+    def __init__(self, game: "Game"):
         self.away_team = Team(
             game.away_abbreviation(), game.away_score(), game.away_name(), game.away_hits(), game.away_errors(), game.away_record(), game.away_special_uniforms()
         )

--- a/data/scoreboard/atbat.py
+++ b/data/scoreboard/atbat.py
@@ -1,8 +1,11 @@
-from data.game import Game
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from data.game import Game
 
 
 class AtBat:
-    def __init__(self, game: Game):
+    def __init__(self, game: "Game"):
 
         self.batter = game.batter()
         self.onDeck = game.on_deck()

--- a/data/scoreboard/bases.py
+++ b/data/scoreboard/bases.py
@@ -1,8 +1,12 @@
-from data.game import Game
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from data.game import Game
 
 
 class Bases:
-    def __init__(self, game: Game):
+    def __init__(self, game: "Game"):
         b1 = game.man_on("first")
         b2 = game.man_on("second")
         b3 = game.man_on("third")

--- a/data/scoreboard/inning.py
+++ b/data/scoreboard/inning.py
@@ -1,5 +1,8 @@
-from data.game import Game
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from data.game import Game
 
 class Inning:
 
@@ -8,7 +11,7 @@ class Inning:
     MIDDLE = "Middle"
     END = "End"
 
-    def __init__(self, game: Game):
+    def __init__(self, game: "Game"):
         self.number = game.inning_number()
         self.state = game.inning_state()
         self.ordinal = game.inning_ordinal()

--- a/data/scoreboard/outs.py
+++ b/data/scoreboard/outs.py
@@ -1,6 +1,9 @@
-from data.game import Game
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from data.game import Game
 
 class Outs:
-    def __init__(self, game: Game):
+    def __init__(self, game: "Game"):
         self.number = game.outs()

--- a/data/scoreboard/pitches.py
+++ b/data/scoreboard/pitches.py
@@ -1,9 +1,14 @@
-from data.game import Game
 import data.pitches
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from data.game import Game
 
 
 class Pitches:
-    def __init__(self, game: Game):
+    def __init__(self, game: "Game"):
         self.balls = game.balls()
         self.strikes = game.strikes()
         self.pitch_count = game.current_pitcher_pitch_count()

--- a/data/scoreboard/postgame.py
+++ b/data/scoreboard/postgame.py
@@ -1,11 +1,18 @@
-from data.game import Game
 import debug
+
+
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from data.game import Game
+
 
 PITCHER_UNKNOWN = "Unknown"
 
 
 class Postgame:
-    def __init__(self, game: Game):
+    def __init__(self, game: "Game"):
 
         self.winning_pitcher = PITCHER_UNKNOWN
         self.winning_pitcher_wins = 0
@@ -45,9 +52,7 @@ class Postgame:
             except:
                 debug.exception("Error getting losing pitcher stats")
 
-
         self.series_status = game.series_status()
-
 
     def __str__(self):
         return "<{} {}> W: {} {}-{}; L: {} {}-{}; S: {} ({})".format(

--- a/data/scoreboard/pregame.py
+++ b/data/scoreboard/pregame.py
@@ -1,13 +1,18 @@
+from typing import TYPE_CHECKING
+
 import tzlocal
 import debug
-from data.game import Game
 from data.time_formats import TIME_FORMAT_12H
 
 PITCHER_TBD = "TBD"
 
 
+if TYPE_CHECKING:
+    from data.game import Game
+
+
 class Pregame:
-    def __init__(self, game: Game, time_format):
+    def __init__(self, game: "Game", time_format):
         self.home_team = game.home_abbreviation()
         self.away_team = game.away_abbreviation()
         self.pregame_weather = game.pregame_weather()
@@ -43,7 +48,7 @@ class Pregame:
                 self.home_starter = "{} ({}-{} {} ERA)".format(name, wins, losses, era)
             except:
                 debug.exception("Error getting away starter stats")
-                
+
         self.national_broadcasts = game.broadcasts()
         self.series_status = game.series_status()
 


### PR DESCRIPTION
Trying to reduce the size of the diff in #674

This moves the `print_game_data_debug` function inside the game class, and updates the typing of the scoreboard items to avoid a circular import problem as a result