### PR TITLE
Fix double buffering crashing during network error moments

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -37,10 +37,11 @@ class Data:
 
     def refresh_game(self):
         # handle double buffering
-        self.games.producer_tick(self.schedule.next_game)
+        status = self.games.producer_tick(self.schedule.next_game)
+        status = update.merge([status] + [g.update() for g in self.games.items if g is not None])
 
         # network requests
-        self.__process_network_status(update.merge(g.update() for g in self.games.items))
+        self.__process_network_status(status)
 
     def refresh_standings(self):
         self.__process_network_status(self.standings.update())

--- a/data/utils/double_buffer.py
+++ b/data/utils/double_buffer.py
@@ -1,8 +1,11 @@
-from typing import Any, Callable
+from typing import Any, Callable, Generic, Optional, TypeVar
+from data.update import UpdateStatus
 import debug
 
+T = TypeVar("T")
 
-class DoubleBuffer:
+
+class DoubleBuffer(Generic[T]):
     """
     This class is used to coordinate data that is fetched on the main thread but
     draw on the render thread (currently, games).
@@ -16,11 +19,11 @@ class DoubleBuffer:
     The result is something kind of like a double buffer from computer graphics.
     """
 
-    def __init__(self, initial_data) -> None:
+    def __init__(self, initial_data: Optional[T]) -> None:
         self.items = (initial_data, initial_data)
         self._reading_next = False
 
-    def next(self):
+    def next(self) -> Optional[T]:
         """
         Called on the render thread when it wants the next game to render.
         """
@@ -28,7 +31,7 @@ class DoubleBuffer:
         self._reading_next = True
         return self.items[1]
 
-    def producer_tick(self, getter: Callable[[Any], Any]):
+    def producer_tick(self, getter: Callable[[Optional[T]], Optional[T]]) -> UpdateStatus:
         """
         Called periodically on the main thread.
         If the render thread has moved on, this copies 'next' into 'current' on one tick,
@@ -36,11 +39,16 @@ class DoubleBuffer:
         """
         if not self._reading_next and (self.items[0] == self.items[1]):
             next = getter(self.items[1])
-            if next is not None and next != self.items[1]:
+            if next is None:
+                return UpdateStatus.FAIL
+            if next != self.items[1]:
                 debug.log("Main thread: replacing 'next' with new data")
                 self.items = (self.items[0], next)
+                return UpdateStatus.SUCCESS
 
         if self._reading_next:
             debug.log("Main thread: mirroring 'next' into 'current'")
             self.items = (self.items[1], self.items[1])
             self._reading_next = False
+
+        return UpdateStatus.DEFERRED


### PR DESCRIPTION
I tried to push a small fix about this earlier but this is actually much more robust. We basically just never need to call `.update` on a None