### PR TITLE
Install rpi-rgb-led-matrix via pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A sample bill of materials (BOM) is located [here](https://www.adafruit.com/wish
 ### Software Installation
 #### Requirements
 You need Git for cloning this repo and PIP for installing the scoreboard software.
-```
+```sh
 sudo apt-get update
 sudo apt-get install git python3-pip
 ```
@@ -116,7 +116,7 @@ sudo apt-get install git python3-pip
 #### Installing the scoreboard software
 This installation process will take about 10-15 minutes. Raspberry Pis aren't the fastest of computers, so be patient!
 
-```
+```sh
 git clone https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard.git
 cd mlb-led-scoreboard/
 sudo ./install.sh
@@ -140,39 +140,39 @@ It will also install the following python libraries that are required for certai
 Additional flags are available for customizing your install:
 
 ```
--a, --skip-all          Skip all dependencies and config installation (equivalent to -c -p -m).
--c, --skip-config       Skip updating JSON configuration files.
--m, --skip-matrix       Skip building matrix driver dependency. Video display will default to emulator mode.
--p, --skip-python       Skip Python 3 installation. Requires manual Python 3 setup if not already installed.
+-a, --skip-all              Skip all dependencies and config installation (equivalent to -c -o -p).
+-c, --skip-config           Skip updating JSON configuration files.
+-o, --skip-optimizations    Skip optimizations for matrix display.
+-p, --skip-python           Skip Python 3 installation. Requires manual Python 3 setup if not already installed.
 
--v, --no-venv           Do not create a virtual environment for the dependencies.
--e, --emulator-only     Do not install dependencies under sudo. Skips building matrix dependencies (equivalent to -m)
--d, --driver            Specify a branch name or commit SHA for the rpi-rgb-led-matrix library. (Optional. Defaults may change.)
+-v, --no-venv               Do not create a virtual environment for the dependencies.
+-s, --no-sudo               Do not install dependencies under sudo. Useful for emulation-only installation.
+-e, --emulator-only         Do not install RPI matrix drivers. Video display will default to software emulation.
 
--f, --force             Try to skip most errors and force install. May be able to recover from previous installer errors.
+-f, --force                 Try to skip most errors and force install. May be able to recover from previous installer errors.
 
--h, --help              Display this help message
+-h, --help                  Display this help message
 ```
 
 #### Installation on Non-Raspberry Pi Hardware
 
 The installation script is designed for physical hardware. When attempting to install it on other platforms, you should not use `sudo` to install the dependencies. In addition, you can pass the `--emulator-only` argument to skip installation steps that aren't required.
 
-```
-sh install.sh --emulator-only
+```sh
+sh install.sh --no-sudo --emulator-only
 ```
 
 #### Updating
 
 A basic update is simple, just pull down the new code:
 
-```
+```sh
 git pull
 ```
 
 However, it is a good idea to re-run the installation script, following prompts as necessary. This will install latest versions of software packages such as the matrix driver library, MLB APIs, and other dependencies. Additionally, custom configuration can be updated through this installer.
 
-```
+```sh
 sudo ./install.sh
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -5,32 +5,32 @@ exec > >(tee -a logs/mlbled.log) 2>&1
 
 SKIP_PYTHON=false
 SKIP_CONFIG=false
-SKIP_MATRIX=false
-NO_SUDO=false
+SKIP_OPTIMIZATIONS=false
+SKIP_SUDO=false
 SKIP_VENV=false
-DRIVER_SHA=d8778b5
 FORCE=false
+
+REQUIREMENTS=requirements.rpi.txt
 
 usage() {
     cat <<USAGE
-    Usage: ./install.sh [-a | --skip-all] [-c | --skip-config] [-m | --skip-matrix] 
-                        [-p | --skip-python] [-v | --no-venv] [-e | --emulator-only] 
-                        [-d <branch_or_commit> | --driver <branch_or_commit>] 
+    Usage: ./install.sh [-a | --skip-all] [-c | --skip-config] [-o | --skip-optimizations]
+                        [-p | --skip-python] [-v | --no-venv] [-s | --no-sudo] [-e | --emulator-only]
                         [-f | --force] [-h | --help]
 
     Options:
-        -a, --skip-all          Skip all dependencies and config installation (equivalent to -c -p -m).
-        -c, --skip-config       Skip updating JSON configuration files.
-        -m, --skip-matrix       Skip building matrix driver dependency. Video display will default to emulator mode.
-        -p, --skip-python       Skip Python 3 installation. Requires manual Python 3 setup if not already installed.
+        -a, --skip-all              Skip all dependencies and config installation (equivalent to -c -o -p).
+        -c, --skip-config           Skip updating JSON configuration files.
+        -o, --skip-optimizations    Skip optimizations for matrix display.
+        -p, --skip-python           Skip Python 3 installation. Requires manual Python 3 setup if not already installed.
 
-        -v, --no-venv           Do not create a virtual environment for the dependencies.
-        -e, --emulator-only     Do not install dependencies under sudo. Skips building matrix dependencies (equivalent to -m)
-        -d, --driver            Specify a branch name or commit SHA for the rpi-rgb-led-matrix library. (Defaults to "$DRIVER_SHA")
+        -v, --no-venv               Do not create a virtual environment for the dependencies.
+        -s, --no-sudo               Do not install dependencies under sudo. Useful for emulation-only installation.
+        -e, --emulator-only         Do not install RPI matrix drivers. Video display will default to software emulation.
 
-        -f, --force             Try to skip most errors and force install. May be able to recover from previous installer errors.
+        -f, --force                 Try to skip most errors and force install. May be able to recover from previous installer errors.
 
-        -h, --help              Display this help message
+        -h, --help                  Display this help message
 USAGE
     exit 1
 }
@@ -74,29 +74,30 @@ while [ $# -gt 0 ]; do
         SKIP_CONFIG=true
         shift
         ;;
-    -m | --skip-matrix)
-        SKIP_MATRIX=true
+    -o | --skip-optimize)
+        SKIP_OPTIMIZATIONS=true
         shift
         ;;
     -a | --skip-all)
         SKIP_CONFIG=true
-        SKIP_MATRIX=true
+        SKIP_OPTIMIZATIONS=true
         SKIP_PYTHON=true
         SKIP_VENV=true
         shift
         ;;
     -e | --emulator-only)
-        SKIP_MATRIX=true
-        NO_SUDO=true
+        REQUIREMENTS=requirements.txt
+        SKIP_OPTIMIZATIONS=true
+        shift
+        ;;
+    -s | --no-sudo)
+        SKIP_OPTIMIZATIONS=true
+        SKIP_SUDO=true
         shift
         ;;
     -v | --no-venv)
         SKIP_VENV=true
         shift
-        ;;
-    -d | --driver)
-        DRIVER_SHA="$2"
-        shift 2
         ;;
     -f | --force)
         FORCE=true
@@ -148,7 +149,7 @@ echo
 
 if [ "$SKIP_VENV" = false ]; then
     echo "Creating virtual environment..."
-    if [ "$NO_SUDO" = false ]; then
+    if [ "$SKIP_SUDO" = false ]; then
         sudo python3 -m venv ./venv
     else
         python3 -m venv ./venv
@@ -158,7 +159,7 @@ if [ "$SKIP_VENV" = false ]; then
     if ! grep -q "#\!/" main.py; then
         if [[ "$OSTYPE" == "darwin"* ]]; then
             sed -i '' '1i\'$'\n''#!'"$(which python3)"$'\n' main.py
-        elif [ "$NO_SUDO" = false ]; then
+        elif [ "$SKIP_SUDO" = false ]; then
             sed -i "1i #\!/usr/bin/sudo $(which python3)" main.py
         else
             sed -i "1i #\!$(which python3)" main.py
@@ -176,40 +177,13 @@ if [ "$SKIP_VENV" = false ]; then
 fi
 PYTHON=$(which python3)
 
-if [ "$NO_SUDO" = false ]; then
-    sudo "$PYTHON" -m pip install -r requirements.txt
+if [ "$SKIP_SUDO" = false ]; then
+    sudo "$PYTHON" -m pip install -r $REQUIREMENTS
 else
-    "$PYTHON" -m pip install -r requirements.txt
+    "$PYTHON" -m pip install -r $REQUIREMENTS
 fi
 
-if [ "$SKIP_MATRIX" = false ]; then
-    echo "Running rgbmatrix installation..."
-    sudo apt-get install -y make gcc g++
-    mkdir submodules -p
-    cd submodules
-
-    if [ -d matrix ]; then
-        echo "'matrix' directory already exists. Assuming rpi-rgb-led-matrix is already installed."
-    else
-        git clone https://github.com/hzeller/rpi-rgb-led-matrix.git matrix
-    fi
-
-    cd matrix
-    # Checkout the branch or commit specified for rpi-rgb-led-matrix
-    git fetch
-    git checkout $DRIVER_SHA
-
-    # If we're on 'detached HEAD' state, git pull has a non-zero exit and fails
-    # Current branch will be a zero-length string (-z) in this state, so test (-n) for non-empty string
-    if [ -n "$(git branch --show-current)" ]; then
-        git pull
-    fi
-
-    make build-python PYTHON="$PYTHON" CYTHON=cython3
-    sudo make install-python PYTHON="$PYTHON"
-
-    cd ../..
-
+if [ "$SKIP_OPTIMIZATIONS" = false ]; then
     echo "------------------------------------"
     echo "  Checking for snd_bcm2835"
     echo "------------------------------------"

--- a/requirements.rpi.txt
+++ b/requirements.rpi.txt
@@ -1,0 +1,1 @@
+git+https://github.com/hzeller/rpi-rgb-led-matrix@6c0cd7b


### PR DESCRIPTION
Installs `rpi-rgb-led-matrix` via new pip build method.

Added `requirements.rpi.txt` which is the default entrypoint for pip reqs in the installer. This is just a git ref to the driver repo with a specific SHA pinned. I updated the CLI flags to support installing from here by default and you can override via `--emulator-only`.

I removed `--driver` since we will no longer support that and changed `-m / --skip-matrix` to `-o / --skip-optimizations`, which is still needed to set `snd_bcm2835` / `isolcpus=3`

Overall the default is still `sudo ./install.sh`, installing on other platforms is something like:

```sh
./install.sh --no-sudo --emulator-only
```