### PR TITLE
Add hide_record_on_high_line_score coordinates option

### DIFF
--- a/coordinates/w128h32.example.json
+++ b/coordinates/w128h32.example.json
@@ -318,7 +318,8 @@
         "font_name": "4x6",
         "x": 19,
         "y": 17
-      }
+      },
+      "hide_record_on_high_line_score": false
     },
     "line_score": {
       "away": {

--- a/coordinates/w128h64.example.json
+++ b/coordinates/w128h64.example.json
@@ -296,7 +296,8 @@
       "home": {
         "x": 30,
         "y": 29
-      }
+      },
+      "hide_record_on_high_line_score": false
     },
     "line_score": {
       "away": {

--- a/coordinates/w192h64.example.json
+++ b/coordinates/w192h64.example.json
@@ -296,7 +296,8 @@
       "home": {
         "x": 30,
         "y": 29
-      }
+      },
+      "hide_record_on_high_line_score": false
     },
     "line_score": {
       "away": {

--- a/coordinates/w32h32.example.json
+++ b/coordinates/w32h32.example.json
@@ -303,7 +303,8 @@
       "home": {
         "x": 4,
         "y": 13
-      }
+      },
+      "hide_record_on_high_line_score": true
     },
     "line_score": {
       "away": {

--- a/coordinates/w64h32.example.json
+++ b/coordinates/w64h32.example.json
@@ -289,7 +289,8 @@
       "home": {
         "x": 15,
         "y": 13
-      }
+      },
+      "hide_record_on_high_line_score": true
     },
     "line_score": {
       "away": {

--- a/coordinates/w64h64.example.json
+++ b/coordinates/w64h64.example.json
@@ -274,7 +274,8 @@
         "font_name": "4x6",
         "x": 18,
         "y": 17
-      }
+      },
+      "hide_record_on_high_line_score": true
     },
     "line_score": {
       "away": {

--- a/renderers/games/teams.py
+++ b/renderers/games/teams.py
@@ -37,8 +37,9 @@ def render_team_banner(
     away_name_end_pos = __render_team_text(canvas, layout, away_colors["text"], away_team, "away", use_full_team_names)
     home_name_end_pos = __render_team_text(canvas, layout, home_colors["text"], home_team, "home", use_full_team_names)
 
-    __render_record_text(canvas, layout, away_colors["text"], away_team, "away", away_name_end_pos)
-    __render_record_text(canvas, layout, home_colors["text"], home_team, "home", home_name_end_pos)
+    if can_show_record_text(layout, [home_team, away_team]):
+        __render_record_text(canvas, layout, away_colors["text"], away_team, "away", away_name_end_pos)
+        __render_record_text(canvas, layout, home_colors["text"], home_team, "home", home_name_end_pos)
 
     if show_score:
         # Number of characters in each score.
@@ -74,6 +75,29 @@ def can_use_full_team_names(layout, teams):
     return True
 
 
+def can_show_record_text(layout, teams):
+    record_coords = layout.coords("teams.record")
+
+    # Global setting is disabled
+    if not record_coords.get("enabled", False):
+        return False
+
+    # Setting for hiding if a line score contains more than 3 total digits (i.e. R, H, or E >= 10)
+    if record_coords.get("hide_record_on_high_line_score", False):
+
+        # For each team, check digits for each line score item. Disable full names if any exceed a single digit.
+        # A 10 error game would be rough, but the edge case is covered...
+        for team in teams:
+            if team.runs > 9 or team.hits > 9 or team.errors > 9:
+                return False
+
+        # No line score column has overflowed
+        return True
+
+    # Global setting is enabled
+    return True
+
+
 def __render_team_text(canvas, layout, text_color, team, homeaway, full_team_names):
     text_color_graphic = graphics.Color(text_color["r"], text_color["g"], text_color["b"])
     coords = layout.coords("teams.name.{}".format(homeaway))
@@ -88,8 +112,6 @@ def __render_team_text(canvas, layout, text_color, team, homeaway, full_team_nam
 
 def __render_record_text(canvas, layout, text_color, team, homeaway, origin):
     if "losses" not in team.record or "wins" not in team.record:
-        return
-    if not layout.coords("teams.record").get("enabled", False):
         return
 
     text_color_graphic = graphics.Color(text_color["r"], text_color["g"], text_color["b"])

--- a/schemas/coordinates/_common.schema.json
+++ b/schemas/coordinates/_common.schema.json
@@ -345,10 +345,11 @@
         "record": {
           "type": "object",
           "properties": {
-            "enabled":  { "type": "boolean" },
-            "position": { "type": "string" },
-            "away":     { "$ref": "#/$defs/named_point" },
-            "home":     { "$ref": "#/$defs/named_point" }
+            "enabled":                        { "type": "boolean" },
+            "position":                       { "type": "string" },
+            "away":                           { "$ref": "#/$defs/named_point" },
+            "home":                           { "$ref": "#/$defs/named_point" },
+            "hide_record_on_high_line_score": { "type": "boolean" }
           }
         },
         "line_score": {

--- a/schemas/coordinates/w128h32.schema.json
+++ b/schemas/coordinates/w128h32.schema.json
@@ -135,7 +135,8 @@
         "enabled":  false,
         "position": "absolute",
         "away": { "font_name": "4x6", "x": 19, "y": 7  },
-        "home": { "font_name": "4x6", "x": 19, "y": 17 }
+        "home": { "font_name": "4x6", "x": 19, "y": 17 },
+        "hide_record_on_high_line_score": false
       },
       "line_score": {
         "away": { "x": 63, "y": 8  },

--- a/schemas/coordinates/w128h64.schema.json
+++ b/schemas/coordinates/w128h64.schema.json
@@ -138,7 +138,8 @@
         "enabled":  false,
         "position": "absolute",
         "away": { "x": 30, "y": 13 },
-        "home": { "x": 30, "y": 29 }
+        "home": { "x": 30, "y": 29 },
+        "hide_record_on_high_line_score": false
       },
       "line_score": {
         "away": { "font_name": "9x18B", "x": 126, "y": 13 },

--- a/schemas/coordinates/w192h64.schema.json
+++ b/schemas/coordinates/w192h64.schema.json
@@ -138,7 +138,8 @@
         "enabled":  false,
         "position": "absolute",
         "away": { "x": 30, "y": 13 },
-        "home": { "x": 30, "y": 29 }
+        "home": { "x": 30, "y": 29 },
+        "hide_record_on_high_line_score": false
       },
       "line_score": {
         "away": { "font_name": "9x18B", "x": 190, "y": 13 },

--- a/schemas/coordinates/w32h32.schema.json
+++ b/schemas/coordinates/w32h32.schema.json
@@ -125,7 +125,8 @@
         "enabled":  false,
         "position": "absolute",
         "away": { "x": 4, "y": 6  },
-        "home": { "x": 4, "y": 13 }
+        "home": { "x": 4, "y": 13 },
+        "hide_record_on_high_line_score": true
       },
       "line_score": {
         "away": { "x": 31, "y": 6  },

--- a/schemas/coordinates/w64h32.schema.json
+++ b/schemas/coordinates/w64h32.schema.json
@@ -137,7 +137,8 @@
         "enabled":  false,
         "position": "absolute",
         "away": { "x": 15, "y": 6  },
-        "home": { "x": 15, "y": 13 }
+        "home": { "x": 15, "y": 13 },
+        "hide_record_on_high_line_score": true
       },
       "line_score": {
         "away": { "x": 62, "y": 6  },

--- a/schemas/coordinates/w64h64.schema.json
+++ b/schemas/coordinates/w64h64.schema.json
@@ -131,7 +131,8 @@
         "enabled":  false,
         "position": "absolute",
         "away": { "font_name": "4x6", "x": 18, "y": 7  },
-        "home": { "font_name": "4x6", "x": 18, "y": 17 }
+        "home": { "font_name": "4x6", "x": 18, "y": 17 },
+        "hide_record_on_high_line_score": true
       },
       "line_score": {
         "away": { "x": 63, "y": 8  },


### PR DESCRIPTION
My apologies if I didn't format this PR correctly. I am still very unfamiliar with git.

This PR adds a "hide_record_on_high_line_score" option to the coordinates files. I have been manually porting this change along for years on my 64x32 board because I want to display team records and there's just barely enough room with short team names when the line score doesn't contain any double digit entries.

Some minor caveats: I believe the record's closing bracket will just barely touch the line score when the record has a three digit number (e.g. 100-62) on my 64x32 board, i.e. there's no space between them. Also, this will prematurely hide records even when there IS enough room when the records are small early in the season and only contain single digit numbers.

One other unrelated note: When I was duplicating the can_use_full_team_names function I noticed that it looks like it might be pulling the shorten_team_name_on_high_line_score option from the wrong config item? This isn't an option I use so I didn't test it but it looked wrong to me when comparing with the example json files.

Thank you for considering this PR.