### PR TITLE
Calculate layout size including chain/parallel flags

### DIFF
--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -87,9 +87,9 @@ class Config:
         self.news_json = json.get("news_ticker", {}) | json.get("weather")
         self.plugin_json = json.get("plugins", {})
 
-        # Get the layout info
-        width = self.matrix_options.cols
-        height = self.matrix_options.rows
+        # Get the layout info. This can differ from panel dimensions if chaining multiple panels together.
+        width = self.matrix_options.cols * self.matrix_options.chain_length
+        height = self.matrix_options.rows * self.matrix_options.parallel
         json = self.__get_layout(width, height)
         self.layout = Layout(json, width, height)
 


### PR DESCRIPTION
Fixes a bug introduced in #700 / #702

Broken line: https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/commit/6aa422abb8f4f0a4af680121e396f00a88bb9a2a#diff-05e0f6293b859f8cb79ca6f1695d5a962449c79b6bc284db6c18d5ad00fd3775R82-R83

Height and width of the layout is always set to single panel dimensions even when using chaining flags.

This worked when we passed the height/width from the matrix object itself which calculates this correctly

https://github.com/MLB-LED-Scoreboard/mlb-led-scoreboard/commit/6aa422abb8f4f0a4af680121e396f00a88bb9a2a#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L38
