### PR TITLE
Implement first-party Pi5 support

### DIFF
--- a/.github/workflows/require_release_branch.yml
+++ b/.github/workflows/require_release_branch.yml
@@ -2,6 +2,7 @@ name: Require release branch
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   check_branch:

--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ You can configure your LED matrix with the same flags used in the [rpi-rgb-led-m
 --led-multiplexing        Multiplexing type: 0 = direct; 1 = strip; 2 = checker; 3 = spiral; 4 = Z-strip; 5 = ZnMirrorZStripe; 6 = coreman; 7 = Kaler2Scan; 8 = ZStripeUneven. (Default: 0)
 --led-limit-refresh       Limit refresh rate to this frequency in Hz. Useful to keep a constant refresh rate on loaded system. 0=no limit. Default: 0
 --led-pwm-dither-bits     Time dithering of lower bits (Default: 0)
+--led-rpi1-rio            On Raspberry Pi 5-family boards, use the experimental RP1 RIO backend instead of RP1 PIO. 0=PIO, 1=RIO. (Default: 0)
 --drop-privileges         Force the matrix driver to drop root privileges after setup. (Default: true)
 
 # The following are specific to mlb-led-scoreboard

--- a/cli.py
+++ b/cli.py
@@ -148,6 +148,14 @@ def _make_parser(defaults) -> argparse.ArgumentParser:
         type=int,
     )
     parser.add_argument(
+        "--led-rp1-rio",
+        action="store",
+        help="On Raspberry Pi 5-family boards, use the experimental RP1 RIO backend instead of RP1 PIO. 0=PIO, 1=RIO. (Default: 0)",
+        default=0,
+        choices=[0, 1],
+        type=int,
+    )
+    parser.add_argument(
         "--drop-privileges",
         action="store_true",
         help="Force the matrix driver to drop root privileges after setup.",

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -352,6 +352,9 @@ If you aren't sure why you're seeing this, there might not be official support f
         if args.led_no_hardware_pulse:
             options.disable_hardware_pulsing = True
 
+        if args.led_rp1_rio != None:
+            options.rp1_rio = args.led_rp1_rio
+
         return options
 
     def __set_log_level(self, json):

--- a/requirements.rpi.txt
+++ b/requirements.rpi.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 
-git+https://github.com/hzeller/rpi-rgb-led-matrix@e947417
+git+https://github.com/hzeller/rpi-rgb-led-matrix@8907235


### PR DESCRIPTION
Upstream support for Raspberry Pi 5 family boards is implemented:

https://github.com/hzeller/rpi-rgb-led-matrix/pull/1886