### PR TITLE
Add MLB.com recap and preview blurbs to game scroll text

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -69,6 +69,7 @@
   "sync_delay_seconds": 0,
   "api_refresh_rate": 5,
   "scrolling_speed": 2,
+  "editorial_blurb": true,
   "debug": false,
   "demo_date": false
 }

--- a/data/blurbs.py
+++ b/data/blurbs.py
@@ -40,7 +40,7 @@ class Blurbs:
             mlb = self._content["editorial"][section]["mlb"]
             headline = mlb.get("headline", "")
             subhead = mlb.get("subhead", "")
-            return " ".join((" — ".join(filter(None, [headline, subhead]))).split())
+            return " ".join((" - ".join(filter(None, [headline, subhead]))).split())
         except (KeyError, TypeError):
             return ""
 

--- a/data/blurbs.py
+++ b/data/blurbs.py
@@ -1,0 +1,50 @@
+import time
+import statsapi
+
+from bullpen.logging import LOGGER
+import data.headers
+
+UPDATE_RATE = 60 * 5
+
+
+# separate API call from the game_content endpoint, so we don't fold this into
+# the Game data updates
+class Blurbs:
+    def __init__(self, game_id):
+        self.game_id = game_id
+        self._content: dict = {}
+        self.starttime = time.time()
+        self.update(force=True)
+
+    def recap(self):
+        return self._blurb("recap")
+
+    def preview(self):
+        return self._blurb("preview")
+
+    def update(self, force=False):
+        if not force and not self.__should_update():
+            return
+        try:
+            self._content = statsapi.get(
+                "game_content",
+                {"gamePk": self.game_id},
+                request_kwargs={"headers": data.headers.API_HEADERS},
+            )
+            self.starttime = time.time()
+        except Exception:
+            LOGGER.exception(f"Error while fetching game {self.game_id} blurb content")
+
+    def _blurb(self, section):
+        try:
+            mlb = self._content["editorial"][section]["mlb"]
+            headline = mlb.get("headline", "")
+            subhead = mlb.get("subhead", "")
+            return " ".join((" — ".join(filter(None, [headline, subhead]))).split())
+        except (KeyError, TypeError):
+            return ""
+
+    def __should_update(self):
+        endtime = time.time()
+        time_delta = endtime - self.starttime
+        return time_delta >= UPDATE_RATE

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -63,6 +63,8 @@ class Config:
         # TODO moving this inside a 'plugin' is a bit weird?
         self.pregame_weather = json["weather"]["pregame"]
 
+        self.editorial_blurb = json["editorial_blurb"]
+
         # Misc config options
         self.time_format = json["time_format"]
         self.end_of_day = json["end_of_day"]

--- a/data/game.py
+++ b/data/game.py
@@ -9,6 +9,7 @@ from data import teams
 from bullpen.api import UpdateStatus
 from data.utils.circular_queue import CircularQueue
 from data.uniforms import Uniforms
+from data.blurbs import Blurbs
 from data.scoreboard import Scoreboard
 from data.scoreboard.postgame import Postgame
 from data.scoreboard.pregame import Pregame
@@ -59,6 +60,7 @@ class Game:
         self._api_refresh_rate = config.api_refresh_rate
         self._status: dict[str, Any] = {}
         self._uniform_data = Uniforms(game_id, config.uniform_types)
+        self._blurb_data = Blurbs(game_id)
 
     def update(self, force=False, testing_params={}) -> UpdateStatus:
         if force or self.__should_update():
@@ -91,6 +93,7 @@ class Game:
                         LOGGER.error("Failed to get game status from schedule")
 
                 self._uniform_data.update()
+                self._blurb_data.update()
                 self.print_game_data_debug()
                 return UpdateStatus.SUCCESS
             except:
@@ -356,36 +359,11 @@ class Game:
             result += "_looking"
         return result
 
-    def _fetch_game_content(self):
-        now = time.time()
-        if hasattr(self, "_game_content_cache") and now - getattr(self, "_game_content_cache_time", 0) < 300:
-            return self._game_content_cache
-        try:
-            content = statsapi.get(
-                "game_content",
-                {"gamePk": self.game_id},
-                request_kwargs={"headers": data.headers.API_HEADERS},
-            )
-            self._game_content_cache = content
-            self._game_content_cache_time = now
-            return content
-        except Exception:
-            return {}
-
-    def _blurb_from(self, section):
-        try:
-            mlb = self._fetch_game_content()["editorial"][section]["mlb"]
-            headline = mlb.get("headline", "")
-            subhead = mlb.get("subhead", "")
-            return " ".join((" — ".join(filter(None, [headline, subhead]))).split())
-        except (KeyError, TypeError):
-            return ""
-
     def game_recap_blurb(self):
-        return self._blurb_from("recap")
+        return self._blurb_data.recap()
 
     def game_preview_blurb(self):
-        return self._blurb_from("preview")
+        return self._blurb_data.preview()
 
     def __should_update(self):
         if self._status.get("abstractGameState") == "Final":

--- a/data/game.py
+++ b/data/game.py
@@ -356,7 +356,40 @@ class Game:
             result += "_looking"
         return result
 
+    def _fetch_game_content(self):
+        now = time.time()
+        if hasattr(self, "_game_content_cache") and now - getattr(self, "_game_content_cache_time", 0) < 300:
+            return self._game_content_cache
+        try:
+            content = statsapi.get(
+                "game_content",
+                {"gamePk": self.game_id},
+                request_kwargs={"headers": data.headers.API_HEADERS},
+            )
+            self._game_content_cache = content
+            self._game_content_cache_time = now
+            return content
+        except Exception:
+            return {}
+
+    def _blurb_from(self, section):
+        try:
+            mlb = self._fetch_game_content()["editorial"][section]["mlb"]
+            headline = mlb.get("headline", "")
+            subhead = mlb.get("subhead", "")
+            return " ".join((" — ".join(filter(None, [headline, subhead]))).split())
+        except (KeyError, TypeError):
+            return ""
+
+    def game_recap_blurb(self):
+        return self._blurb_from("recap")
+
+    def game_preview_blurb(self):
+        return self._blurb_from("preview")
+
     def __should_update(self):
+        if self._status.get("abstractGameState") == "Final":
+            return False
         endtime = time.time()
         time_delta = endtime - self.starttime
         return time_delta >= self._api_refresh_rate

--- a/data/scoreboard/postgame.py
+++ b/data/scoreboard/postgame.py
@@ -52,6 +52,7 @@ class Postgame:
                 LOGGER.exception("Error getting losing pitcher stats")
 
         self.series_status = game.series_status()
+        self.recap_blurb = game.game_recap_blurb()
 
     def __str__(self):
         return "<{} {}> W: {} {}-{}; L: {} {}-{}; S: {} ({})".format(

--- a/data/scoreboard/postgame.py
+++ b/data/scoreboard/postgame.py
@@ -55,7 +55,7 @@ class Postgame:
         self.recap_blurb = game.game_recap_blurb()
 
     def __str__(self):
-        return "<{} {}> W: {} {}-{}; L: {} {}-{}; S: {} ({})".format(
+        return "<{} {}> W: {} {}-{}; L: {} {}-{}; S: {} ({}); Recap: {}".format(
             self.__class__.__name__,
             hex(id(self)),
             self.winning_pitcher,
@@ -66,4 +66,5 @@ class Postgame:
             self.losing_pitcher_losses,
             self.save_pitcher,
             self.save_pitcher_saves,
+            self.recap_blurb,
         )

--- a/data/scoreboard/pregame.py
+++ b/data/scoreboard/pregame.py
@@ -51,6 +51,7 @@ class Pregame:
 
         self.national_broadcasts = game.broadcasts()
         self.series_status = game.series_status()
+        self.preview_blurb = game.game_preview_blurb()
 
     def __convert_time(self, game_time_utc):
         """Converts MLB's pregame times (UTC) into the local time zone"""

--- a/data/scoreboard/pregame.py
+++ b/data/scoreboard/pregame.py
@@ -61,7 +61,7 @@ class Pregame:
         return game_time_utc.astimezone(tzlocal.get_localzone()).strftime(time_str)
 
     def __str__(self):
-        s = "<{} {}> {} @ {}; {}; {} vs {}; Forecast: {}; TV: {}".format(
+        s = "<{} {}> {} @ {}; {}; {} vs {}; Forecast: {}; TV: {}; Preview: {}".format(
             self.__class__.__name__,
             hex(id(self)),
             self.away_team,
@@ -71,5 +71,6 @@ class Pregame:
             self.home_starter,
             self.pregame_weather,
             self.national_broadcasts,
+            self.preview_blurb,
         )
         return s

--- a/renderers/games/postgame.py
+++ b/renderers/games/postgame.py
@@ -32,6 +32,9 @@ def _render_decision_scroll(canvas, layout, colors, postgame, text_pos, is_playo
     if postgame.save_pitcher:
         scroll_text += " SV: {} ({})".format(postgame.save_pitcher, postgame.save_pitcher_saves)
 
+    if postgame.recap_blurb:
+        scroll_text += "  —  " + postgame.recap_blurb
+
     if is_playoffs:
         scroll_text += "   " + postgame.series_status
 

--- a/renderers/games/postgame.py
+++ b/renderers/games/postgame.py
@@ -10,13 +10,20 @@ NORMAL_GAME_LENGTH = 9
 
 
 def render_postgame(
-    canvas, layout: Layout, colors: Color, postgame: Postgame, scoreboard: Scoreboard, text_pos, is_playoffs
+    canvas,
+    layout: Layout,
+    colors: Color,
+    postgame: Postgame,
+    scoreboard: Scoreboard,
+    text_pos,
+    editorial_blurb,
+    is_playoffs,
 ):
     _render_final_inning(canvas, layout, colors, scoreboard)
-    return _render_decision_scroll(canvas, layout, colors, postgame, text_pos, is_playoffs)
+    return _render_decision_scroll(canvas, layout, colors, postgame, text_pos, editorial_blurb, is_playoffs)
 
 
-def _render_decision_scroll(canvas, layout, colors, postgame, text_pos, is_playoffs):
+def _render_decision_scroll(canvas, layout, colors, postgame, text_pos, editorial_blurb, is_playoffs):
     coords = layout.coords("final.scrolling_text")
     font = layout.font("final.scrolling_text")
     color = colors.graphics_color("final.scrolling_text")
@@ -32,8 +39,8 @@ def _render_decision_scroll(canvas, layout, colors, postgame, text_pos, is_playo
     if postgame.save_pitcher:
         scroll_text += " SV: {} ({})".format(postgame.save_pitcher, postgame.save_pitcher_saves)
 
-    if postgame.recap_blurb:
-        scroll_text += "  —  " + postgame.recap_blurb
+    if editorial_blurb and postgame.recap_blurb:
+        scroll_text += "  -  " + postgame.recap_blurb
 
     if is_playoffs:
         scroll_text += "   " + postgame.series_status

--- a/renderers/games/pregame.py
+++ b/renderers/games/pregame.py
@@ -7,9 +7,18 @@ from bullpen.util import center_text_position, scrolling_text
 
 
 def render_pregame(
-    canvas, layout: Layout, colors: Color, pregame: Pregame, probable_starter_pos, pregame_weather, is_playoffs
+    canvas,
+    layout: Layout,
+    colors: Color,
+    pregame: Pregame,
+    probable_starter_pos,
+    pregame_weather,
+    editorial_blurb,
+    is_playoffs,
 ):
-    text_len = _render_pregame_info(canvas, layout, colors, pregame, probable_starter_pos, pregame_weather, is_playoffs)
+    text_len = _render_pregame_info(
+        canvas, layout, colors, pregame, probable_starter_pos, pregame_weather, editorial_blurb, is_playoffs
+    )
 
     if layout.state_is_warmup():
         _render_warmup(canvas, layout, colors, pregame)
@@ -37,7 +46,9 @@ def _render_warmup(canvas, layout, colors, pregame):
     graphics.DrawText(canvas, font["font"], warmup_x, coords["y"], color, warmup_text)
 
 
-def _render_pregame_info(canvas, layout, colors, pregame: Pregame, probable_starter_pos, pregame_weather, is_playoffs):
+def _render_pregame_info(
+    canvas, layout, colors, pregame: Pregame, probable_starter_pos, pregame_weather, editorial_blurb, is_playoffs
+):
     coords = layout.coords("pregame.scrolling_text")
     font = layout.font("pregame.scrolling_text")
     color = colors.graphics_color("pregame.scrolling_text")
@@ -48,8 +59,8 @@ def _render_pregame_info(canvas, layout, colors, pregame: Pregame, probable_star
     if pregame_weather and pregame.pregame_weather:
         pitchers_text += " Weather: " + pregame.pregame_weather
 
-    if pregame.preview_blurb:
-        pitchers_text += "  —  " + pregame.preview_blurb
+    if editorial_blurb and pregame.preview_blurb:
+        pitchers_text += "  -  " + pregame.preview_blurb
 
     if is_playoffs:
         pitchers_text += "   " + pregame.series_status

--- a/renderers/games/pregame.py
+++ b/renderers/games/pregame.py
@@ -48,6 +48,9 @@ def _render_pregame_info(canvas, layout, colors, pregame: Pregame, probable_star
     if pregame_weather and pregame.pregame_weather:
         pitchers_text += " Weather: " + pregame.pregame_weather
 
+    if pregame.preview_blurb:
+        pitchers_text += "  —  " + pregame.preview_blurb
+
     if is_playoffs:
         pitchers_text += "   " + pregame.series_status
 

--- a/renderers/main.py
+++ b/renderers/main.py
@@ -84,6 +84,7 @@ class MainRenderer:
                 pregame,
                 self.scrolling_text_pos,
                 self.data.config.pregame_weather,
+                self.data.config.editorial_blurb,
                 self.data.config.is_postseason(),
             )
             self.__update_scrolling_text_pos(pos, self.canvas.width)
@@ -98,6 +99,7 @@ class MainRenderer:
                 final,
                 scoreboard,
                 self.scrolling_text_pos,
+                self.data.config.editorial_blurb,
                 self.data.config.is_postseason(),
             )
             self.__update_scrolling_text_pos(pos, self.canvas.width)

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -416,6 +416,12 @@
       "maximum": 6,
       "default": 2
     },
+    "editorial_blurb": {
+      "description": "Include the MLB.com editorial recap/preview blurb in game scroll text?",
+      "type": "boolean",
+      "default": true,
+      "x-format": "checkbox"
+    },
     "debug": {
       "description": "Should the board enable extra logging?",
       "type": "boolean",

--- a/tests/fixtures/config.example.json
+++ b/tests/fixtures/config.example.json
@@ -53,6 +53,7 @@
   "api_refresh_rate": 5,
   "sync_delay_seconds": 0,
   "scrolling_speed": 2,
+  "editorial_blurb": true,
   "debug": false,
   "demo_date": false,
   "test_config": {

--- a/tests/fixtures/config.json
+++ b/tests/fixtures/config.json
@@ -60,6 +60,7 @@
   "api_refresh_rate": 5,
   "sync_delay_seconds": 0,
   "scrolling_speed": 1,
+  "editorial_blurb": true,
   "debug": true,
   "demo_date": false,
   "test_config": {


### PR DESCRIPTION
- Game._fetch_game_content() pulls the MLB editorial section from the game_content API endpoint, cached 5 min per game
- game_recap_blurb() and game_preview_blurb() build "headline — subhead" strings, returning "" when content has not yet been published (typical for the first ~10-30 minutes after a game ends)
- Postgame: recap blurb is appended to the W/L scrolling line
- Pregame: preview blurb is appended to the pitchers/broadcasts/weather scrolling line
- Stop refreshing game data once abstractGameState is "Final" to avoid pointless API polling on completed games