### PR TITLE
Add handling for rpi-rgb-led-matrix hard-coded version string

### DIFF
--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -352,8 +352,12 @@ If you aren't sure why you're seeing this, there might not be official support f
         if args.led_no_hardware_pulse:
             options.disable_hardware_pulsing = True
 
-        if args.led_rp1_rio != None:
-            options.rp1_rio = args.led_rp1_rio
+        if args.led_rp1_rio is not None:
+            try:
+                options.rp1_rio = args.led_rp1_rio
+            except AttributeError:
+                LOGGER.warning("Your compiled RGB Matrix Library is out of date.")
+                LOGGER.warning("The --led-rp1-rio argument will not work until it is updated.")
 
         return options
 

--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,7 @@ SKIP_CONFIG=false
 SKIP_OPTIMIZATIONS=false
 SKIP_SUDO=false
 SKIP_VENV=false
-
-REQUIREMENTS=requirements.rpi.txt
+SKIP_DRIVER=false
 
 usage() {
     cat <<USAGE
@@ -79,7 +78,7 @@ while [ $# -gt 0 ]; do
         shift
         ;;
     -e | --emulator-only)
-        REQUIREMENTS=requirements.txt
+        SKIP_DRIVER=true
         SKIP_OPTIMIZATIONS=true
         shift
         ;;
@@ -165,9 +164,23 @@ fi
 PYTHON=$(which python3)
 
 if [ "$SKIP_SUDO" = false ]; then
-    sudo "$PYTHON" -m pip install -r $REQUIREMENTS
+    sudo "$PYTHON" -m pip install -r requirements.txt
 else
-    "$PYTHON" -m pip install -r $REQUIREMENTS
+    "$PYTHON" -m pip install -r requirements.txt
+fi
+
+# rpi-rgb-led-matrix hard-codes its version string, this ensures pip doesn't skip recompiling the bindings due to the version never changing
+if [ "$SKIP_DRIVER" = false ]; then
+    echo
+    echo "------------------------------------"
+    echo "  Rebuilding RGB matrix binding..."
+    echo "------------------------------------"
+    echo
+    if [ "$SKIP_SUDO" = false ]; then
+        sudo "$PYTHON" -m pip install --force-reinstall --no-cache-dir --no-deps -r requirements.rpi.txt
+    else
+        "$PYTHON" -m pip install --force-reinstall --no-cache-dir --no-deps -r requirements.rpi.txt
+    fi
 fi
 
 if [ "$SKIP_OPTIMIZATIONS" = false ]; then

--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     from driver import RGBMatrix, __version__
 
     matrix = RGBMatrix(options=config.matrix_options)
-    config.set_layout(matrix.height, matrix.width)
+    config.set_layout(matrix.width, matrix.height)
 
     try:
         main(matrix, config)

--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     from driver import RGBMatrix, __version__
 
     matrix = RGBMatrix(options=config.matrix_options)
-    config.set_layout(matrix.width, matrix.height)
+    config.set_layout(width=matrix.width, height=matrix.height)
 
     try:
         main(matrix, config)

--- a/requirements.rpi.txt
+++ b/requirements.rpi.txt
@@ -1,3 +1,1 @@
--r requirements.txt
-
 git+https://github.com/hzeller/rpi-rgb-led-matrix@8907235


### PR DESCRIPTION
- Always installs `requirements.txt`
- Installs driver with `--force-reinstall --no-cache-dir` to force driver reinstall even if version string matches
- Add a guard for the `rp1-rio` accessor on `RGBMatrixOptions` in case people don't reinstall