### PR TITLE
Avoid using bare except: clause, which catches KeyboardInterrupt

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -34,9 +34,7 @@ class Data:
         status = UpdateStatus.FAIL
         try:
             status = plugin.update()
-        except KeyboardInterrupt as e:
-            raise e
-        except:
+        except Exception:
             LOGGER.exception("Failure while updating plugin %s", name)
 
         self.__process_network_status(status)

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -151,7 +151,7 @@ class Config:
                 # Try and cast whatever the user passed into a float
                 rate = float(value)
                 self.rotation_rates[key] = rate
-            except:
+            except Exception:
                 # Use the default rotate rate if it fails
                 LOGGER.warning(
                     'Unable to convert rotate_rates["{}"] to a Float. Using default value. ({})'.format(

--- a/data/config/layout.py
+++ b/data/config/layout.py
@@ -47,9 +47,7 @@ class Layout:
         """
         try:
             return self.__get_font_object(self.coords(keypath)[FONTNAME_KEY])
-        except KeyboardInterrupt as e:
-            raise e
-        except:
+        except Exception:
             return self.__get_font_object(self.default_font_name)
 
     def coords(self, keypath):

--- a/data/game.py
+++ b/data/game.py
@@ -90,7 +90,7 @@ class Game:
                         self._status = next(
                             g["games"][0]["status"] for g in scheduled["dates"] if g["date"] == self.date
                         )
-                    except:
+                    except Exception:
                         LOGGER.error("Failed to get game status from schedule")
                 else:
                     self._status = self._current_data["gameData"]["status"]
@@ -99,7 +99,7 @@ class Game:
                 self._blurb_data.update()
                 self.print_game_data_debug()
                 return UpdateStatus.SUCCESS
-            except:
+            except Exception:
                 LOGGER.exception("Networking Error while refreshing the current game data.")
                 return UpdateStatus.FAIL
         return UpdateStatus.DEFERRED
@@ -246,12 +246,12 @@ class Game:
                 stats = self._current_data["liveData"]["boxscore"]["teams"]["home"]["players"][ID]["seasonStats"][
                     "pitching"
                 ]
-            except:
+            except Exception:
                 try:
                     stats = self._current_data["liveData"]["boxscore"]["teams"]["away"]["players"][ID]["seasonStats"][
                         "pitching"
                     ]
-                except:
+                except Exception:
                     return ""
 
         return stats[stat]
@@ -259,41 +259,41 @@ class Game:
     def probable_pitcher_id(self, team):
         try:
             return self._current_data["gameData"]["probablePitchers"][team]["id"]
-        except:
+        except Exception:
             return None
 
     def decision_pitcher_id(self, decision):
         try:
             return self._current_data["liveData"]["decisions"][decision]["id"]
-        except:
+        except Exception:
             return None
 
     def batter(self):
         try:
             batter_id = self._current_data["liveData"]["linescore"]["offense"]["batter"]["id"]
             return self.boxscore_name(batter_id)
-        except:
+        except Exception:
             return ""
 
     def in_hole(self):
         try:
             batter_id = self._current_data["liveData"]["linescore"]["offense"]["inHole"]["id"]
             return self.boxscore_name(batter_id)
-        except:
+        except Exception:
             return ""
 
     def on_deck(self):
         try:
             batter_id = self._current_data["liveData"]["linescore"]["offense"]["onDeck"]["id"]
             return self.boxscore_name(batter_id)
-        except:
+        except Exception:
             return ""
 
     def pitcher(self):
         try:
             pitcher_id = self._current_data["liveData"]["linescore"]["defense"]["pitcher"]["id"]
             return self.boxscore_name(pitcher_id)
-        except:
+        except Exception:
             return ""
 
     def balls(self):
@@ -314,7 +314,7 @@ class Game:
                     play["details"]["type"]["code"],
                     play["details"]["type"]["description"],
                 )
-        except:
+        except Exception:
             return None
 
     def current_pitcher_pitch_count(self):
@@ -325,26 +325,26 @@ class Game:
                 return self._current_data["liveData"]["boxscore"]["teams"]["away"]["players"][ID]["stats"]["pitching"][
                     "numberOfPitches"
                 ]
-            except:
+            except Exception:
                 return self._current_data["liveData"]["boxscore"]["teams"]["home"]["players"][ID]["stats"]["pitching"][
                     "numberOfPitches"
                 ]
-        except:
+        except Exception:
             return 0
 
     def note(self):
         try:
             return self._current_data["liveData"]["linescore"]["note"]
-        except:
+        except Exception:
             return None
 
     def reason(self):
         try:
             return self._status["reason"]
-        except:
+        except Exception:
             try:
                 return self._status["detailedState"].split(":")[1].strip()
-            except:
+            except Exception:
                 return None
 
     def broadcasts(self):

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -38,7 +38,7 @@ class Schedule:
             try:
                 # add sportId=51 to additionally get WBC games
                 all_games = statsapi.schedule(self.date.strftime("%Y-%m-%d"), sportId="1,51")
-            except:
+            except Exception:
                 LOGGER.exception("Networking error while refreshing schedule")
                 return UpdateStatus.FAIL
             else:

--- a/data/scoreboard/postgame.py
+++ b/data/scoreboard/postgame.py
@@ -24,7 +24,7 @@ class Postgame:
                 self.winning_pitcher = game.full_name(winner)
                 self.winning_pitcher_wins = game.pitcher_stat(winner, "wins", winner_side)
                 self.winning_pitcher_losses = game.pitcher_stat(winner, "losses", winner_side)
-            except:
+            except Exception:
                 LOGGER.exception("Error getting winning pitcher stats")
 
         self.save_pitcher = None
@@ -35,7 +35,7 @@ class Postgame:
             try:
                 self.save_pitcher = game.full_name(save)
                 self.save_pitcher_saves = game.pitcher_stat(save, "saves", winner_side)
-            except:
+            except Exception:
                 LOGGER.exception("Error getting save pitcher stats")
 
         self.losing_pitcher = PITCHER_UNKNOWN
@@ -48,7 +48,7 @@ class Postgame:
                 self.losing_pitcher = game.full_name(loser)
                 self.losing_pitcher_wins = game.pitcher_stat(loser, "wins", loser_side)
                 self.losing_pitcher_losses = game.pitcher_stat(loser, "losses", loser_side)
-            except:
+            except Exception:
                 LOGGER.exception("Error getting losing pitcher stats")
 
         self.series_status = game.series_status()

--- a/data/scoreboard/pregame.py
+++ b/data/scoreboard/pregame.py
@@ -20,7 +20,7 @@ class Pregame:
 
         try:
             self.start_time = self.__convert_time(game.datetime())
-        except:
+        except Exception:
             self.start_time = "TBD"
 
         self.status = game.status()
@@ -34,7 +34,7 @@ class Pregame:
                 losses = game.pitcher_stat(away_id, "losses", "away")
                 era = game.pitcher_stat(away_id, "era", "away")
                 self.away_starter = "{} ({}-{} {} ERA)".format(name, wins, losses, era)
-            except:
+            except Exception:
                 LOGGER.exception("Error getting away starter stats")
 
         self.home_starter = PITCHER_TBD
@@ -46,7 +46,7 @@ class Pregame:
                 losses = game.pitcher_stat(home_id, "losses", "home")
                 era = game.pitcher_stat(home_id, "era", "home")
                 self.home_starter = "{} ({}-{} {} ERA)".format(name, wins, losses, era)
-            except:
+            except Exception:
                 LOGGER.exception("Error getting away starter stats")
 
         self.national_broadcasts = game.broadcasts()

--- a/main.py
+++ b/main.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 
     try:
         main(matrix, config)
-    except:
+    except Exception:
         LOGGER.exception("Untrapped error in main!")
         sys.exit(1)
     finally:

--- a/news/src/mlb_led_scoreboard_news/dates.py
+++ b/news/src/mlb_led_scoreboard_news/dates.py
@@ -16,7 +16,7 @@ class Dates:
             if year == now.year and end_date < now:
                 data_d = statsapi.get("season", {"sportId": 1, "seasonId": year + 1})
                 self.__parse_important_dates(data_d["seasons"][0], year + 1)
-        except:
+        except Exception:
             LOGGER.exception("Failed to refresh important dates")
             self.important_dates = [{"text": "None", "date": datetime(3000, 1, 1), "max_days": 1}]
         try:
@@ -25,7 +25,7 @@ class Dates:
                 if d.count("-") == 1:
                     d = f"{year}-{d}"
                 self.__add_date(d, date["text"], date.get("max_days", 365))
-        except:
+        except Exception:
             LOGGER.exception("Failed to parse important dates from config")
 
         LOGGER.debug("Important dates: %s", self.important_dates)

--- a/standings/src/mlb_led_scoreboard_standings/standings.py
+++ b/standings/src/mlb_led_scoreboard_standings/standings.py
@@ -72,7 +72,7 @@ class Standings(PluginData):
                     self.leagues["AL"] = League(postseason_data, "AL")
                     self.leagues["NL"] = League(postseason_data, "NL")
 
-            except:
+            except Exception:
                 LOGGER.exception("Failed to refresh standings.")
                 return UpdateStatus.FAIL
             else:

--- a/tests/display_team_colors.py
+++ b/tests/display_team_colors.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
         while True:
             try:
                 config = Config()
-            except:
+            except Exception:
                 logging.exception("Error error re-loading config")
                 pass
             canvas = draw_teams(canvas, config)


### PR DESCRIPTION
I was wondering why sometimes the service took a while to restart, turns out it was because SIGINT was being caught all over the place