### PR TITLE
Update driver for Pi4 and below compatibility

### DIFF
--- a/requirements.rpi.txt
+++ b/requirements.rpi.txt
@@ -1,1 +1,1 @@
-git+https://github.com/hzeller/rpi-rgb-led-matrix@e947417
+git+https://github.com/hzeller/rpi-rgb-led-matrix@1ee4f76

--- a/requirements.rpi.txt
+++ b/requirements.rpi.txt
@@ -1,1 +1,1 @@
-git+https://github.com/hzeller/rpi-rgb-led-matrix@8907235
+git+https://github.com/hzeller/rpi-rgb-led-matrix@e947417


### PR DESCRIPTION
~~Reverts the driver SHA bump since there is a known issue with that fails to compile on Raspberry Pi OS for Pi versions < 5~~

Rolls forward driver with latest changes to compile in Raspberry Pi OS for Pi 4 and below.
