### PR TITLE
Add option to pick leagues in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ See [`config.schema.json`](config.schema.json) for a schema for configuration fi
 "scrolling_speed"                 Integer Sets how fast the scrolling text scrolls. Supports an integer between 0 and 6.
 "sync_delay_seconds"              Integer Delays game updates to sychronize with broadcasts. May introduce delay before rendering live games. Must be at least 0, defaults to 0 (no delay).
 "api_refresh_rate"                Integer Refresh the game data from the MLB API every X seconds. Must be at least 3, default is 10.
+"leagues"                         Array   Which leagues to pull games from. Currently the options are "MLB" and "WBC".
 "editorial_blurb"                 Bool    Append the MLB.com editorial blurb (headline + subhead) to the scrolling text on pregame and postgame screens. Recaps are routinely published; previews are rare. See the Editorial Blurbs feature section.
 "debug"                           Bool    Game and other debug data is written to your console.
 "demo_date"                       String  A date in the format YYYY-MM-DD from which to pull data to demonstrate the scoreboard. A value of `false` will disable demo mode.

--- a/config.example.json
+++ b/config.example.json
@@ -68,6 +68,10 @@
   "end_of_day": "00:00",
   "sync_delay_seconds": 0,
   "api_refresh_rate": 5,
+  "leagues": [
+    "MLB",
+    "WBC"
+  ],
   "scrolling_speed": 2,
   "editorial_blurb": true,
   "debug": false,

--- a/data/config/__init__.py
+++ b/data/config/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 from datetime import datetime, timedelta
 from collections import defaultdict, namedtuple
-from typing import Mapping
+from typing import Mapping, Union
 from math import ceil
 
 from bullpen.api.config import MLBConfig
@@ -19,6 +19,7 @@ from bullpen.logging import LOGGER
 from data import status
 from data.config.color import Color
 from data.config.layout import Layout
+from data.leagues import LEAGUES
 from data.paths import *
 import cli
 from driver import RGBMatrixOptions
@@ -70,6 +71,7 @@ class Config:
         self.end_of_day = json["end_of_day"]
         self.sync_delay_seconds = json["sync_delay_seconds"]
         self.api_refresh_rate = json["api_refresh_rate"]
+        self.schedule_sport_ids, self.schedule_league_ids = _load_leagues(json["leagues"])
 
         self.debug = json["debug"]
         self.demo_date = json["demo_date"]
@@ -459,3 +461,24 @@ def _extract_uniform_types(teams_json: dict) -> dict:
                 uniform_types[key] = key.replace("_", " ")
 
     return uniform_types
+
+
+def _load_leagues(leagues_json: Union[str, list[str]]) -> tuple[str, str]:
+    if isinstance(leagues_json, str):
+        leagues_json = [leagues_json]
+    if not isinstance(leagues_json, list) or not all(isinstance(l, str) for l in leagues_json):
+        raise ValueError(f"Invalid 'leagues' config. Expected a string or list of strings, got {leagues_json}.")
+    if not leagues_json:
+        raise ValueError("Invalid 'leagues' config. Expected a non-empty list of league names, e.g. ['MLB'].")
+
+    sport_ids = []
+    league_ids = []
+
+    for league_name in leagues_json:
+        league = LEAGUES.get(league_name)
+        if not league:
+            raise ValueError(f"Invalid league name '{league_name}' in config. Valid options: {list(LEAGUES.keys())}")
+        sport_ids.append(str(league.sportId))
+        league_ids.extend([str(lid) for lid in league.leagueIds])
+
+    return ",".join(sport_ids), ",".join(league_ids)

--- a/data/leagues.py
+++ b/data/leagues.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class League:
+    name: str
+    sportId: int
+    leagueIds: list[int]
+
+
+LEAGUES = {
+    "MLB": League(name="MLB", sportId=1, leagueIds=[103, 104]),
+    "WBC": League(name="WBC", sportId=51, leagueIds=[159, 160]),
+}

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -18,7 +18,6 @@ GAMES_REFRESH_RATE = 15
 class Schedule:
     def __init__(self, config: Config) -> None:
         self.config = config
-        self.date = self.config.parse_today()
         self.starttime = time.time()
         self.current_idx = 0
 
@@ -32,12 +31,12 @@ class Schedule:
 
     def update(self, force=False) -> UpdateStatus:
         if force or self.__should_update():
-            self.date = self.config.parse_today()
-            LOGGER.debug("Updating schedule for %s", self.date)
+            date = self.config.parse_today()
+            LOGGER.debug("Updating schedule for %s", date)
             self.starttime = time.time()
             try:
                 # add sportId=51 to additionally get WBC games
-                all_games = statsapi.schedule(self.date.strftime("%Y-%m-%d"), sportId="1,51")
+                all_games = statsapi.schedule(date.strftime("%Y-%m-%d"), sportId=self.config.schedule_sport_ids, leagueId=self.config.schedule_league_ids)
             except Exception:
                 LOGGER.exception("Networking error while refreshing schedule")
                 return UpdateStatus.FAIL
@@ -50,7 +49,6 @@ class Schedule:
                 self._data_wait_queue.push((priority, games))
 
                 priority, games = self._data_wait_queue.peek()
-
                 if len(games) > 0:
                     self.current_idx %= len(games)
                 else:

--- a/data/schedule.py
+++ b/data/schedule.py
@@ -31,12 +31,14 @@ class Schedule:
 
     def update(self, force=False) -> UpdateStatus:
         if force or self.__should_update():
-            date = self.config.parse_today()
+            date = self.config.parse_today().strftime("%Y-%m-%d")
             LOGGER.debug("Updating schedule for %s", date)
             self.starttime = time.time()
             try:
                 # add sportId=51 to additionally get WBC games
-                all_games = statsapi.schedule(date.strftime("%Y-%m-%d"), sportId=self.config.schedule_sport_ids, leagueId=self.config.schedule_league_ids)
+                all_games = statsapi.schedule(
+                    date, sportId=self.config.schedule_sport_ids, leagueId=self.config.schedule_league_ids
+                )
             except Exception:
                 LOGGER.exception("Networking error while refreshing schedule")
                 return UpdateStatus.FAIL

--- a/data/status.py
+++ b/data/status.py
@@ -47,6 +47,7 @@ DELAYED_AIR_QUALITY = "Delayed: Air Quality"  # Live
 DELAYED_POWER = "Delayed: Power"  # Live
 DELAYED_RAIN = "Delayed: Rain"  # Live
 DELAYED_SNOW = "Delayed: Snow"  # Live
+DELAYED_TIEBREAKER = "Delayed: Tiebreaker"  # Live
 DELAYED_START = "Delayed Start"  # Preview
 DELAYED_START_CEREMONY = "Delayed Start: Ceremony"  # Preview
 DELAYED_START_COLD = "Delayed Start: Cold"  # Preview
@@ -282,6 +283,7 @@ GAME_STATE_IRREGULAR = [
     DELAYED_POWER,
     DELAYED_RAIN,
     DELAYED_SNOW,
+    DELAYED_TIEBREAKER,
     DELAYED_START,
     DELAYED_START_CEREMONY,
     DELAYED_START_COLD,

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -409,6 +409,20 @@
       "default": 5,
       "minimum": 1
     },
+    "leagues": {
+      "description": "Which leagues should games be pulled from?",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "MLB",
+          "WBC"
+        ]
+      },
+      "default": ["MLB", "WBC"],
+      "uniqueItems": true,
+      "x-format": "choices"
+    },
     "scrolling_speed": {
       "description": "How quickly should text scroll on the board",
       "type": "number",
@@ -453,7 +467,7 @@
       "description": "Required status of the game for it to be included in a rule. By default, any game that day will be a candidate if the teams match",
       "meta:enum": {
         "live": "Game is currently in progress",
-        "live_in_inning": "Game is currently in progress and has reached the inning specified in the teams array (if any)",
+        "live_in_inning": "Game is currently in progress and is not in between innings",
         "pregame": "Game has not started yet",
         "game_over": "Game has finished"
       }


### PR DESCRIPTION
Alternative config option to the 'sport_ids' from #765. Uses named keys and checks that the league is one of the ones we have defined metadata for 