### PR TITLE
Add workflow to automatically reset dev after release

### DIFF
--- a/.github/workflows/update-dev.yml
+++ b/.github/workflows/update-dev.yml
@@ -1,0 +1,23 @@
+name: Update Development Branch on Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  update-dev:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'dev'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Reset dev to master
+        run: |
+          git checkout -B dev
+          git push origin dev --force


### PR DESCRIPTION
I do this process by hand as part of a release, this just automates the happy path

There's still case where we commit directly to master, we'd have to handle that by hand. It's infrequent, so not very worried about it.